### PR TITLE
fix(report): correct client-type target mapping in SOPs stored procedure

### DIFF
--- a/database/migrations/2026_07_07_000001_fix_sops_procedure_client_type_targets.php
+++ b/database/migrations/2026_07_07_000001_fix_sops_procedure_client_type_targets.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Reinstall the stored procedure so the daily target CASE matches
+     * App\Models\ClientType (PM = 1, PH = 2, AM = 3). The previous version
+     * applied the AM target to PM and the PH target to AM.
+     */
+    public function up(): void
+    {
+        // Drop the procedure if it exists
+        DB::statement('DROP PROCEDURE IF EXISTS GetSOPsAndCallRateData');
+
+        // Create the stored procedure from SQL file
+        $sqlFile = database_path('sql/procedures/GetSOPsAndCallRateData.sql');
+
+        if (!file_exists($sqlFile)) {
+            throw new \Exception("SQL file not found: {$sqlFile}");
+        }
+
+        $sql = file_get_contents($sqlFile);
+
+        if ($sql === false) {
+            throw new \Exception("Failed to read SQL file: {$sqlFile}");
+        }
+
+        DB::statement($sql);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement('DROP PROCEDURE IF EXISTS GetSOPsAndCallRateData');
+    }
+};

--- a/database/sql/procedures/GetSOPsAndCallRateData.sql
+++ b/database/sql/procedures/GetSOPsAndCallRateData.sql
@@ -35,13 +35,14 @@ BEGIN
       );
 
     -- Get daily target based on client type with fallback to settings
+    -- Client type ids must match App\Models\ClientType: PM = 1, PH = 2, AM = 3
     CASE p_client_type_id
-        WHEN 1 THEN -- AM
-            SELECT COALESCE(CAST(value AS UNSIGNED), 2) INTO v_daily_target
-            FROM settings WHERE `key` = 'daily_am_target' LIMIT 1;
-        WHEN 3 THEN -- PH
+        WHEN 2 THEN -- PH
             SELECT COALESCE(CAST(value AS UNSIGNED), 8) INTO v_daily_target
             FROM settings WHERE `key` = 'daily_ph_target' LIMIT 1;
+        WHEN 3 THEN -- AM
+            SELECT COALESCE(CAST(value AS UNSIGNED), 2) INTO v_daily_target
+            FROM settings WHERE `key` = 'daily_am_target' LIMIT 1;
         ELSE -- PM (default)
             SELECT COALESCE(CAST(value AS UNSIGNED), 6) INTO v_daily_target
             FROM settings WHERE `key` = 'daily_pm_target' LIMIT 1;


### PR DESCRIPTION
## Problem
The daily-target CASE in `GetSOPsAndCallRateData` mapped client type **1** to the AM target and type **3** to the PH target, while `App\Models\ClientType` defines **PM = 1, PH = 2, AM = 3**. As a result:

- Doctors reports (PM, id 1) used the AM daily target (2) instead of the PM target (6)
- AM accounts reports (id 3) used the PH target (8) instead of the AM target (2)
- Pharmacies (id 2) fell through to the ELSE branch and used the PM target (6) instead of the PH target (8)

Visit **counts** were unaffected (the counting filter uses `client_type_id` correctly), but `daily_visit_target`, `monthly_visit_target`, `sops`, and `call_rate` percentages were all computed against the wrong target — one of the reasons SOPs numbers looked wrong to the field team.

## Fix
- Correct the CASE mapping in `database/sql/procedures/GetSOPsAndCallRateData.sql` (PM=1 → ELSE/default, PH=2, AM=3), with a comment pinning the ids to `App\Models\ClientType`.
- Add migration `2026_07_07_000001_fix_sops_procedure_client_type_targets` that drops and reinstalls the procedure from the fixed file (same pattern as `2025_08_21_205702`).

## Verify
Run `php artisan migrate`, then open the SOPs & Call Rate report per client type and confirm the daily target column shows 6 (PM), 8 (PH), 2 (AM) — matching the `settings` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)