### PR TITLE
fix(plan): use seeded district-manager role name in ClientManager

### DIFF
--- a/app/Filament/Resources/PlanResource/ClientManager.php
+++ b/app/Filament/Resources/PlanResource/ClientManager.php
@@ -33,7 +33,7 @@ class ClientManager
             self::prepareData();
         }
 
-        if (auth()->user()->hasRole('district_manager') && $day) {
+        if (auth()->user()->hasRole('district-manager') && $day) {
             $key = $type ? "{$day}-{$type}" : $day;
             return self::$clients[$key] ?? [];
         }
@@ -66,7 +66,7 @@ class ClientManager
             ->pluck("name_en", "id")
             ->toArray();
 
-        if (auth()->user()->hasRole("district_manager")) {
+        if (auth()->user()->hasRole("district-manager")) {
             $dates = DateHelper::calculateVisitDates();
             $days = array_map(
                 fn($date) => Str::lower(Carbon::parse($date)->format("D")),


### PR DESCRIPTION
## Problem
`ClientManager` checks `hasRole('district_manager')` (underscore) in two places, but the role seeded in `RolesAndPermissionsSeeder` is **`district-manager`** (hyphen). Both checks always return false, so district managers never get their day-specific planned-clients lists and silently fall through to the generic area-derived list.

## Fix
Use the seeded role name `district-manager` in both checks (`getClients` and `prepareData`). These were the only two underscore occurrences in the codebase.

## Verify
Log in as a district manager and open the plan form: day-keyed client lists (built from `Visit::districtManagerClients()`) should now be returned instead of the generic list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)