### PR TITLE
feat(visit): allow any manager as visit accompany on double visits

### DIFF
--- a/app/Filament/Resources/VisitResource/Forms/VisitForm.php
+++ b/app/Filament/Resources/VisitResource/Forms/VisitForm.php
@@ -98,7 +98,7 @@ class VisitForm
             ])
             ->required(fn($get) => $get('call_type_id') == CallType::where('name', 'Double')->value('id'))
             ->placeholder('Search name')
-            ->options(options: User::myDistrictManager()->pluck('name', 'id'))
+            ->options(options: User::managers()->orderBy('name')->pluck('name', 'id'))
             ->getOptionLabelUsing(fn ($value): ?string => User::find($value)?->name)
             ->preload();
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -102,6 +102,11 @@ class User extends Authenticatable implements FilamentUser
         return $query->where('id', $id);
     }
 
+    public function scopeManagers($query)
+    {
+        return $query->role(['district-manager', 'area-manager', 'country-manager']);
+    }
+
     public function areas()
     {
         return $this->belongsToMany(Area::class);


### PR DESCRIPTION
## Problem
The "Visit Accompany" select on the visit form offered exactly one option — the rep's direct manager (`User::myDistrictManager()` is `where('id', parent_id)`). When a sales, marketing, area, or country manager joined a rep in the field, the double visit could not be recorded for them. (Raised by the field team in the July issues document.)

## Change
- Add `User::managers()` scope: users holding any of the `district-manager`, `area-manager`, or `country-manager` roles.
- Populate the accompany select from that scope (sorted by name) instead of `myDistrictManager()`.

Unchanged, and already working as the field team asked:
- The accompany field still requires call type **Double** (and is rejected otherwise), so double visits stay clearly distinct from single visits.
- The SOPs stored procedure already credits a double visit to both the rep and the accompanying manager.

## Verify
As a medical rep, create a visit with call type "Double": the accompany list should now include all district/area/country managers, not just the direct manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)