### PR TITLE
feat(vacation): add per-user annual entitlement and balance visibility

### DIFF
--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -70,6 +70,13 @@ class UserResource extends Resource
                     ->dehydrated(static fn(null|string $state): bool => filled($state))
                     ->label(static fn(Page $livewire): string => ($livewire instanceof Pages\EditUser) ? 'New Password' : 'Password')
                     ->maxLength(32),
+                TextInput::make('annual_vacation_days')
+                    ->label('Annual Vacation Days')
+                    ->numeric()
+                    ->default(21)
+                    ->minValue(0)
+                    ->step(0.5)
+                    ->required(),
                 CheckboxList::make('roles')
                     ->relationship('roles','display_name')
                     ->columns(2)

--- a/app/Filament/Resources/VacationResource.php
+++ b/app/Filament/Resources/VacationResource.php
@@ -6,14 +6,17 @@ use App\Filament\Resources\VacationResource\Pages;
 use App\Filament\Resources\VacationResource\RelationManagers;
 use App\Models\User;
 use App\Models\Vacation;
+use App\Models\VacationDuration;
 use App\Models\VacationRequest;
 use App\Models\VacationType;
+use App\Services\VacationCalculator;
 use App\Traits\ResourceHasPermission;
 use Awcodes\FilamentTableRepeater\Components\TableRepeater;
 use Carbon\Carbon;
 use Closure;
 use Filament\Forms;
 use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Form;
@@ -101,12 +104,66 @@ class VacationResource extends Resource
                         ])->disableItemMovement()
                         ->defaultItems(1),
                     ])->compact(),
+                Placeholder::make('balance_summary')
+                    ->label('Vacation Balance')
+                    ->content(function ($get, $record) {
+                        $calculator = app(VacationCalculator::class);
+
+                        $requestedDays = 0;
+                        foreach ($get('vacationDurations') ?? [] as $duration) {
+                            if (blank($duration['start'] ?? null) || blank($duration['end'] ?? null))
+                                continue;
+
+                            $requestedDays += $calculator->calculateTotalDuration(
+                                $duration['start'],
+                                $duration['end'],
+                                $duration['start_shift'] ?? 'AM',
+                                $duration['end_shift'] ?? 'PM'
+                            );
+                        }
+
+                        $user = $record?->repUser ?? auth()->user();
+
+                        if (!$user)
+                            return 'Requesting '.$requestedDays.' day(s)';
+
+                        $remainingDays = self::getRemainingBalance($user, $record?->id);
+
+                        return 'Requesting '.$requestedDays.' day(s), '.$user->name.' has '.$remainingDays.' remaining day(s) this year';
+                    }),
             ]);
+    }
+
+    /**
+     * Remaining annual balance for a user: entitlement minus approved
+     * vacation days spent in the current year.
+     */
+    public static function getRemainingBalance(User $user, ?int $excludeRequestId = null): float
+    {
+        $spentDays = VacationDuration::query()
+            ->join('vacation_requests as vr', 'vr.id', '=', 'vacation_durations.vacation_request_id')
+            ->where('vr.user_id', $user->id)
+            ->where('vr.approved', '>', 0)
+            ->when($excludeRequestId, fn($query) => $query->where('vr.id', '!=', $excludeRequestId))
+            ->whereYear('vacation_durations.start', now()->year)
+            ->sum('vacation_durations.duration');
+
+        return (float) ($user->annual_vacation_days ?? 21) - (float) $spentDays;
     }
 
     public static function table(Table $table): Table
     {
         return $table
+            ->modifyQueryUsing(fn (Builder $query) => $query
+                ->withSum('vacationDurations as requested_days', 'duration')
+                ->addSelect([
+                    'approved_spent_days' => VacationDuration::query()
+                        ->join('vacation_requests as vr', 'vr.id', '=', 'vacation_durations.vacation_request_id')
+                        ->whereColumn('vr.user_id', 'vacation_requests.user_id')
+                        ->where('vr.approved', '>', 0)
+                        ->whereYear('vacation_durations.start', now()->year)
+                        ->selectRaw('COALESCE(SUM(vacation_durations.duration), 0)'),
+                ]))
             ->columns([
                 TextColumn::make('repUser.name')
                     ->label('Medical Rep')
@@ -122,6 +179,15 @@ class VacationResource extends Resource
                     ->dateTime('d-M-Y')
                     ->sortable()
                     ->searchable(),
+                TextColumn::make('requested_days')
+                    ->label('Requested Days')
+                    ->state(fn($record) => $record->requested_days ?? $record->duration)
+                    ->sortable(),
+                TextColumn::make('remaining_balance')
+                    ->label('Remaining Balance')
+                    ->state(fn($record) => $record->repUser
+                        ? $record->repUser->annual_vacation_days - $record->approved_spent_days
+                        : null),
                 IconColumn::make('approved')
                     ->colors(function($record){
                         if($record->approved > 0)

--- a/app/Filament/Resources/VacationsReportResource.php
+++ b/app/Filament/Resources/VacationsReportResource.php
@@ -38,7 +38,7 @@ class VacationsReportResource extends Resource
                 TextColumn::make('spent_days')
                     ->label('Spent Days'),
                 TextColumn::make('remaning_days')
-                    ->state(fn($record) => 21 - $record->spent_days)
+                    ->state(fn($record) => $record->annual_vacation_days - $record->spent_days)
                     ->label('Remaining Days'),
 
                 // TextColumn::make('start_date')
@@ -88,6 +88,7 @@ class VacationsReportResource extends Resource
         return VacationRequest::select(
             'users.id as id',
             'users.name as medical_rep',
+            'users.annual_vacation_days as annual_vacation_days',
             'vacation_requests.approved as approved',
             DB::raw('GROUP_CONCAT( vacation_types.name SEPARATOR ", ") AS vacation_types'),
             DB::raw('SUM(

--- a/app/Filament/Resources/VacationsReportResource/Pages/ListVacationsReports.php
+++ b/app/Filament/Resources/VacationsReportResource/Pages/ListVacationsReports.php
@@ -108,7 +108,7 @@ class ListVacationsReports extends ListRecords implements HasInfolists
         $vacation_types = $records->pluck('vacation_types')->map(fn($item) => explode(', ',$item))->flatten()->map(fn($item) => trim($item))->unique();
         $summary['vacation_types'] = $vacation_types->implode(', ');
         $summary['total_spent_days'] = $records->sum('spent_days');
-        $summary['total_remaining_days'] = 21 *  $summary['medical_reps_count'] - $summary['total_spent_days'];
+        $summary['total_remaining_days'] = $records->sum('annual_vacation_days') - $summary['total_spent_days'];
         $model = new ReportSummary();
         $model->fill($summary);
         return $model;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -48,6 +48,7 @@ class User extends Authenticatable implements FilamentUser
         'password',
         'parent_id',
         'is_active',
+        'annual_vacation_days',
     ];
 
     /**
@@ -70,6 +71,7 @@ class User extends Authenticatable implements FilamentUser
     protected $casts = [
         'email_verified_at' => 'datetime',
         'is_active' => 'boolean',
+        'annual_vacation_days' => 'float',
     ];
 
     /**

--- a/database/migrations/2026_07_07_000001_add_annual_vacation_days_to_users_table.php
+++ b/database/migrations/2026_07_07_000001_add_annual_vacation_days_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->decimal('annual_vacation_days', 5, 1)->default(21)->after('is_active');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('annual_vacation_days');
+        });
+    }
+};


### PR DESCRIPTION
## Problem

The annual leave balance was hardcoded to 21 days in two places:

- `VacationsReportResource` — the Remaining Days column computed `21 - spent_days`
- `ListVacationsReports` — the summary computed `total_remaining_days = 21 * medical_reps_count - total_spent_days`

On top of that, the vacation request/approval UI never showed how many days a request totals nor how many days the employee has left, so approvers had no balance context when approving or rejecting.

## What this PR adds

- **Migration**: `annual_vacation_days` decimal(5,1) column on `users`, default 21 (`database/migrations/2026_07_07_000001_add_annual_vacation_days_to_users_table.php`)
- **User model**: `annual_vacation_days` added to `$fillable` and `$casts` (float)
- **UserResource form**: numeric "Annual Vacation Days" input (default 21, min 0, step 0.5) so admins can configure per-user entitlements
- **VacationsReportResource**: query now selects `users.annual_vacation_days`; Remaining Days is computed as `annual_vacation_days - spent_days`
- **ListVacationsReports summary**: total remaining = sum of the in-scope reps' entitlements minus total spent days (the report is grouped one row per user, so summing the selected entitlement column gives the exact total)
- **VacationResource table**: new "Requested Days" column (`withSum` over the request's durations) and "Remaining Balance" column (requester's entitlement minus approved spent days for the current year, via a correlated subquery — no N+1)
- **VacationResource form**: reactive "Vacation Balance" placeholder under the durations repeater showing "Requesting X day(s), <user> has Y remaining day(s) this year", visible to both requester and approver; the current request is excluded from the spent calculation when editing

Approval logic itself is untouched.

## How to verify

1. Run `php artisan migrate` (adds the column with default 21, so existing behavior is preserved out of the box).
2. Edit a user in Admin management → Users and set a custom Annual Vacation Days value.
3. Open Reports → Vacations report: Remaining Days (per row and in the summary) now reflects the per-user entitlement.
4. Open Requests → Vacations: the table shows Requested Days and Remaining Balance; create/edit a request and change durations — the Vacation Balance line updates reactively with the requested total and remaining balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)