### PR TITLE
feat(report): add samples distribution report with per-rep totals and export

### DIFF
--- a/app/Exports/SamplesReportExport.php
+++ b/app/Exports/SamplesReportExport.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace App\Exports;
+
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Style\Border;
+
+class SamplesReportExport implements FromCollection, WithHeadings, WithStyles
+{
+    use Exportable;
+
+    private $query;
+    private $dateRange;
+    private $records;
+
+    public function __construct($query, $dateRange = null)
+    {
+        $this->query = $query;
+        $this->dateRange = $dateRange;
+    }
+
+    public function collection()
+    {
+        try {
+            $data = $this->getRecords();
+
+            if ($data->isEmpty()) {
+                return collect([
+                    ['No data available for the selected criteria']
+                ]);
+            }
+
+            return $data->map(function ($record) {
+                return [
+                    $record->visit_date ? $record->visit_date->format('Y-m-d') : '',
+                    $record->medical_rep ?? '',
+                    $record->client_name ?? '',
+                    $record->product_name ?? '',
+                    $record->samples_count ?? 0,
+                ];
+            });
+        } catch (\Exception $e) {
+            // Return error message if data collection fails
+            return collect([
+                ['Error collecting data: ' . $e->getMessage()]
+            ]);
+        }
+    }
+
+    public function headings(): array
+    {
+        return [
+            'Visit Date',
+            'Delivered By',
+            'Client',
+            'Product',
+            'Samples',
+        ];
+    }
+
+    public function styles(Worksheet $sheet)
+    {
+        // Set column widths
+        $sheet->getColumnDimension('A')->setWidth(15);
+        $sheet->getColumnDimension('B')->setWidth(25);
+        $sheet->getColumnDimension('C')->setWidth(30);
+        $sheet->getColumnDimension('D')->setWidth(25);
+        $sheet->getColumnDimension('E')->setWidth(12);
+
+        // Style the header row
+        $sheet->getStyle('A1:E1')->applyFromArray([
+            'font' => [
+                'bold' => true,
+                'color' => ['rgb' => 'FFFFFF'],
+                'size' => 12,
+            ],
+            'fill' => [
+                'fillType' => Fill::FILL_SOLID,
+                'startColor' => ['rgb' => '2C3E50'],
+            ],
+            'alignment' => [
+                'horizontal' => Alignment::HORIZONTAL_CENTER,
+                'vertical' => Alignment::VERTICAL_CENTER,
+            ],
+            'borders' => [
+                'allBorders' => [
+                    'borderStyle' => Border::BORDER_THIN,
+                    'color' => ['rgb' => '000000'],
+                ],
+            ],
+        ]);
+
+        // Set row height for header
+        $sheet->getRowDimension(1)->setRowHeight(25);
+
+        // Style the data rows
+        $lastRow = $sheet->getHighestRow();
+        if ($lastRow > 1) {
+            $sheet->getStyle("A2:E{$lastRow}")->applyFromArray([
+                'borders' => [
+                    'allBorders' => [
+                        'borderStyle' => Border::BORDER_THIN,
+                        'color' => ['rgb' => 'DDDDDD'],
+                    ],
+                ],
+                'alignment' => [
+                    'horizontal' => Alignment::HORIZONTAL_CENTER,
+                    'vertical' => Alignment::VERTICAL_CENTER,
+                ],
+            ]);
+
+            // Bold the samples column
+            $sheet->getStyle("E2:E{$lastRow}")->getFont()->setBold(true);
+        }
+
+        // Freeze the header row
+        $sheet->freezePane('A2');
+
+        // Add a summary row at the bottom if there are records
+        if ($lastRow > 1) {
+            $summaryRow = $lastRow + 2;
+
+            // Add summary labels
+            $sheet->setCellValue("A{$summaryRow}", 'Summary');
+            $sheet->setCellValue("B{$summaryRow}", 'Medical Reps: ' . $this->getMedicalRepsCount());
+            $sheet->setCellValue("C{$summaryRow}", 'Records: ' . $this->getRecordCount());
+            $sheet->setCellValue("D{$summaryRow}", 'Products: ' . $this->getProductsCount());
+            $sheet->setCellValue("E{$summaryRow}", 'Total Samples: ' . $this->getTotalSum());
+
+            // Style summary row
+            $sheet->getStyle("A{$summaryRow}:E{$summaryRow}")->applyFromArray([
+                'font' => [
+                    'bold' => true,
+                    'size' => 11,
+                ],
+                'fill' => [
+                    'fillType' => Fill::FILL_SOLID,
+                    'startColor' => ['rgb' => 'F8F9FA'],
+                ],
+                'borders' => [
+                    'allBorders' => [
+                        'borderStyle' => Border::BORDER_THIN,
+                        'color' => ['rgb' => '000000'],
+                    ],
+                ],
+            ]);
+        }
+    }
+
+    /**
+     * Generate filename for the export
+     */
+    public function getFilename(): string
+    {
+        $dateRange = $this->dateRange ?? 'all_dates';
+        return 'samples_report_' . $dateRange . '_' . now()->format('Y-m-d_H-i-s') . '.xlsx';
+    }
+
+    /**
+     * Get total sum of distributed samples
+     */
+    public function getTotalSum(): int
+    {
+        return $this->getRecords()->sum('samples_count');
+    }
+
+    /**
+     * Get count of records
+     */
+    public function getRecordCount(): int
+    {
+        return $this->getRecords()->count();
+    }
+
+    /**
+     * Get count of medical reps in the report
+     */
+    public function getMedicalRepsCount(): int
+    {
+        return $this->getRecords()->pluck('user_id')->unique()->count();
+    }
+
+    /**
+     * Get count of products in the report
+     */
+    public function getProductsCount(): int
+    {
+        return $this->getRecords()->pluck('product_name')->unique()->count();
+    }
+
+    /**
+     * Fetch and cache the report records
+     */
+    private function getRecords()
+    {
+        if ($this->records === null) {
+            $this->records = $this->query->get();
+        }
+
+        return $this->records;
+    }
+}

--- a/app/Filament/Resources/SamplesReportResource.php
+++ b/app/Filament/Resources/SamplesReportResource.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Exports\SamplesReportExport;
+use App\Filament\Resources\SamplesReportResource\Pages;
+use App\Models\Product;
+use App\Models\User;
+use App\Models\Visit;
+use App\Traits\ResourceHasPermission;
+use Filament\Forms\Components\DatePicker;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Columns\Summarizers\Sum;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Grouping\Group;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class SamplesReportResource extends Resource
+{
+    use ResourceHasPermission;
+    protected static ?string $model = Visit::class;
+    protected static ?string $permissionName = 'samples-report';
+    protected static ?string $label = 'Samples report';
+
+    protected static ?string $navigationGroup = 'Reports';
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+    protected static ?string $navigationLabel = 'Samples Report';
+    protected static ?string $slug = 'samples-report';
+
+    protected static $medicalReps;
+    protected static $products;
+
+    public static function getEloquentQuery(): Builder
+    {
+        return Visit::query()
+            ->select(
+                'product_visits.id as id',
+                'visits.id as visit_id',
+                'visits.user_id as user_id',
+                'visits.visit_date as visit_date',
+                'users.name as medical_rep',
+                'clients.name_en as client_name',
+                'products.name as product_name',
+                'product_visits.count as samples_count',
+            )
+            ->join('product_visits', 'product_visits.visit_id', '=', 'visits.id')
+            ->leftJoin('users', 'users.id', '=', 'visits.user_id')
+            ->leftJoin('clients', 'clients.id', '=', 'visits.client_id')
+            ->leftJoin('products', 'products.id', '=', 'product_visits.product_id')
+            ->where('visits.status', 'visited')
+            ->where('product_visits.count', '>', 0)
+            ->orderBy('visits.visit_date', 'DESC');
+    }
+
+    public static function getRecordRouteKeyName(): string|null {
+        return 'product_visits.id';
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('visit_date')
+                    ->date('Y-m-d')
+                    ->label('Visit Date'),
+                TextColumn::make('medical_rep')
+                    ->label('Delivered By'),
+                TextColumn::make('client_name')
+                    ->label('Client'),
+                TextColumn::make('product_name')
+                    ->label('Product'),
+                TextColumn::make('samples_count')
+                    ->label('Samples')
+                    ->summarize(Sum::make()->label('Total')),
+            ])
+            ->groups([
+                Group::make('medical_rep')
+                    ->label('Medical Rep'),
+            ])
+            ->defaultGroup('medical_rep')
+            ->filters([
+                Tables\Filters\Filter::make('dates_range')
+                ->form([
+                        DatePicker::make('from_date')
+                            ->default(today()->startOfMonth()),
+                        DatePicker::make('to_date')
+                            ->default(today()->endOfMonth()),
+                    ])->columns(2)
+                ->query(function (Builder $query, array $data): Builder {
+                    return $query
+                        ->when(
+                            $data['from_date'],
+                            fn (Builder $query, $date): Builder => $query->whereDate('visits.visit_date', '>=', $date)
+                        )
+                        ->when(
+                            $data['to_date'],
+                            fn (Builder $query, $date): Builder => $query->whereDate('visits.visit_date', '<=', $date));
+                }),
+                Tables\Filters\SelectFilter::make('user_id')
+                    ->label('Medical Rep')
+                    ->multiple()
+                    ->options(self::getMedicalReps())
+                    ->query(function (Builder $query, array $data): Builder {
+                        if(count($data['values'])){
+                            return $query->whereIn('visits.user_id', $data['values']);
+                        }
+                        else
+                            return $query;
+                        }),
+                Tables\Filters\SelectFilter::make('product_id')
+                    ->label('Product')
+                    ->multiple()
+                    ->options(self::getProducts())
+                    ->query(function (Builder $query, array $data): Builder {
+                        if(count($data['values'])){
+                            return $query->whereIn('product_visits.product_id', $data['values']);
+                        }
+                        else
+                            return $query;
+                        }),
+            ])
+            ->headerActions([
+                Action::make('export')
+                    ->label('Export to Excel')
+                    ->icon('heroicon-o-document-arrow-down')
+                    ->color('success')
+                    ->requiresConfirmation()
+                    ->modalHeading('Export Samples Report')
+                    ->modalDescription('This will export the samples distribution data based on current filters to an Excel file.')
+                    ->modalSubmitActionLabel('Yes, Export')
+                    ->action(function ($livewire) {
+                        try {
+                            $query = $livewire->getFilteredTableQuery();
+
+                            // Get current date range from filters
+                            $dateRange = $livewire->tableFilters['dates_range'] ?? [];
+                            $fromDate = $dateRange['from_date'] ?? null;
+                            $toDate = $dateRange['to_date'] ?? null;
+
+                            $dateRangeString = '';
+                            if ($fromDate && $toDate) {
+                                $dateRangeString = $fromDate . '_to_' . $toDate;
+                            } elseif ($fromDate) {
+                                $dateRangeString = 'from_' . $fromDate;
+                            } elseif ($toDate) {
+                                $dateRangeString = 'until_' . $toDate;
+                            }
+
+                            $export = new SamplesReportExport($query, $dateRangeString);
+                            return $export->download($export->getFilename());
+                        } catch (\Exception $e) {
+                            // Handle export errors gracefully
+                            return redirect()->back()->with('error', 'Export failed: ' . $e->getMessage());
+                        }
+                    })
+            ])
+            ->actions([
+            ])
+            ->bulkActions([
+            ]);
+    }
+
+    private static function getMedicalReps(): array
+    {
+        if(self::$medicalReps)
+            return self::$medicalReps;
+
+        self::$medicalReps = User::allMine()->pluck('name','id')->toArray();
+        return self::$medicalReps;
+    }
+
+    private static function getProducts(): array
+    {
+        if(self::$products)
+            return self::$products;
+
+        self::$products = Product::pluck('name','id')->toArray();
+        return self::$products;
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListSamplesReports::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/SamplesReportResource/Pages/ListSamplesReports.php
+++ b/app/Filament/Resources/SamplesReportResource/Pages/ListSamplesReports.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Filament\Resources\SamplesReportResource\Pages;
+
+use App\Filament\Resources\SamplesReportResource;
+use App\Models\Reports\ReportSummary;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Infolists\Concerns\InteractsWithInfolists;
+use Filament\Infolists\Contracts\HasInfolists;
+use Filament\Infolists\Infolist;
+use Filament\Pages\Actions;
+use Filament\Resources\Pages\ListRecords;
+use Illuminate\Database\Eloquent\Model;
+
+class ListSamplesReports extends ListRecords implements HasInfolists
+{
+    use InteractsWithInfolists;
+
+    protected static string $resource = SamplesReportResource::class;
+    protected static string $view = 'filament.admin.pages.list-report-with-summary';
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            // Actions\CreateAction::make(),
+        ];
+    }
+
+    public function getBreadcrumbs(): array
+    {
+        return [];
+    }
+
+    public function getTableRecordKey(Model $model):string
+    {
+        return 'id';
+    }
+
+    public function summaryInfolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->record($this->getSummary())
+            ->schema([
+                TextEntry::make('from_date')
+                    ->columnSpan([
+                        'sm' => 1,
+                        'md' => 1,
+                        'xl' => 2,
+                    ])
+                    ->label('From Date'),
+                TextEntry::make('to_date')
+                    ->columnSpan([
+                        'sm' => 1,
+                        'md' => 1,
+                        'xl' => 2,
+                    ])
+                    ->label('To Date'),
+                TextEntry::make('medical_reps_count')
+                    ->label('Medical Reps'),
+                TextEntry::make('products_count')
+                    ->label('Products'),
+                TextEntry::make('visits_count')
+                    ->label('Visits'),
+                TextEntry::make('total_samples')
+                    ->label('Total Samples'),
+            ])
+        ->columns([
+            'sm' => 1,
+            'md' => 2,
+            'lg' => 2,
+            'xl' => 4,
+        ]);
+    }
+
+    private function getSummary(): Model{
+        $query = self::$resource::getEloquentQuery();
+        $records = $this->applyFiltersToTableQuery($query)->get();
+        $summary['from_date'] = $this->table->getFilter('dates_range')->getState()['from_date'];
+        $summary['to_date'] = $this->table->getFilter('dates_range')->getState()['to_date'];
+        $summary['medical_reps_count'] = $records->pluck('user_id')->unique()->count();
+        $summary['products_count'] = $records->pluck('product_name')->unique()->count();
+        $summary['visits_count'] = $records->pluck('visit_id')->unique()->count();
+        $summary['total_samples'] = $records->sum('samples_count');
+        $model = new ReportSummary();
+        $model->fill($summary);
+        return $model;
+    }
+}

--- a/app/Models/Visit.php
+++ b/app/Models/Visit.php
@@ -109,7 +109,8 @@ class Visit extends Model
     }
     public function products()
     {
-        return $this->belongsToMany(Product::class,'product_visits');
+        return $this->belongsToMany(Product::class,'product_visits')
+            ->withPivot('count');
     }
 
     public function bundles()

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -73,6 +73,7 @@ class RolesAndPermissionsSeeder extends Seeder
         'sales-report',
         'vacations-report',
         'visit-report',
+        'samples-report',
     ];
 
     /**


### PR DESCRIPTION
## Problem

Sample quantities are recorded per visit in `product_visits.count` (the "Samples" field on the visit form), but no report aggregates them. It is currently impossible to track how many samples were distributed, per doctor/client or per medical rep, or to export that data.

## What this PR adds

- **`Visit::products()` now includes `->withPivot('count')`** so sample quantities are accessible through the relation.
- **New "Samples Report" resource** under the *Reports* navigation group (`app/Filament/Resources/SamplesReportResource.php`):
  - Detail rows: visit date, delivered by (rep), client, product, samples count — sourced from `product_visits` joined to visits/users/clients/products.
  - Only counts **visited**, non-deleted visits with a samples count > 0. The existing `GetMineScope` still applies, so users only see their own hierarchy.
  - Filters: date range (defaults to the current month), medical rep (multi-select, options from `User::allMine()`), product (multi-select).
  - Table grouped by medical rep by default, with a Sum summarizer on the samples column — per-rep subtotals and a grand total are visible directly in the table.
  - House-style summary card (`ListSamplesReports`, using the shared `list-report-with-summary` view): date range, reps count, products count, visits count, and total samples for the filtered period.
- **Excel export** (`app/Exports/SamplesReportExport.php`, maatwebsite/excel) wired to a header "Export to Excel" action that exports the **currently filtered** rows, with styled headers and a summary row (reps / records / products / total samples), following the ExpensesReport export pattern.
- **Permissions**: `samples-report` added to the report models list in `database/seeders/RolesAndPermissionsSeeder.php`, so `view samples-report` / `view-any samples-report` permissions are created and the resource is visible via `ResourceHasPermission` (resource sets `$permissionName = 'samples-report'`).

## How to verify

1. Re-run the seeder so the new permission exists and is granted: `php artisan db:seed --class=RolesAndPermissionsSeeder` (roles' permissions are synced; super-admin gets it automatically).
2. Log in as a user with the `view samples-report` permission — *Samples Report* appears under **Reports**.
3. Record a visit with products and sample counts, mark it visited, then open the report: one row per product with the correct count; cancelled/planned and soft-deleted visits are excluded.
4. Adjust the date range / rep / product filters and confirm rows, per-rep group subtotals, total, and the summary card update.
5. Click **Export to Excel** and confirm the downloaded file matches the filtered table, including the summary row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)