### PR TITLE
feat(report): add all-activity SOPs report with per-role targets

### DIFF
--- a/app/Exports/AllActivitySOPsReportExport.php
+++ b/app/Exports/AllActivitySOPsReportExport.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Exports;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Style\Border;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+class AllActivitySOPsReportExport implements FromCollection, WithHeadings, WithStyles
+{
+    use Exportable;
+
+    private Collection $rows;
+    private ?string $dateRange;
+
+    public function __construct(Collection $rows, ?string $dateRange = null)
+    {
+        $this->rows = $rows;
+        $this->dateRange = $dateRange;
+    }
+
+    public function collection()
+    {
+        if ($this->rows->isEmpty()) {
+            return collect([
+                ['No data available for the selected criteria'],
+            ]);
+        }
+
+        return $this->rows->map(function ($row) {
+            $row = collect($row);
+
+            return [
+                $row->get('id', ''),
+                $row->get('name', ''),
+                $row->get('role_name', ''),
+                $row->get('working_days', 0),
+                $row->get('actual_working_days', 0),
+                $row->get('am_visits', 0),
+                $row->get('am_daily_target', 0),
+                $row->get('am_monthly_target', 0),
+                $row->get('am_sops', 0),
+                $row->get('pm_visits', 0),
+                $row->get('pm_daily_target', 0),
+                $row->get('pm_monthly_target', 0),
+                $row->get('pm_sops', 0),
+                $row->get('ph_visits', 0),
+                $row->get('ph_daily_target', 0),
+                $row->get('ph_monthly_target', 0),
+                $row->get('ph_sops', 0),
+                $row->get('total_visits', 0),
+                $row->get('call_rate', 0),
+            ];
+        });
+    }
+
+    public function headings(): array
+    {
+        return [
+            'ID',
+            'User',
+            'Role',
+            'Working Days',
+            'Actual Working Days',
+            'AM Visits',
+            'AM Daily Target',
+            'AM Monthly Target',
+            'AM SOPs %',
+            'PM Visits',
+            'PM Daily Target',
+            'PM Monthly Target',
+            'PM SOPs %',
+            'PH Visits',
+            'PH Daily Target',
+            'PH Monthly Target',
+            'PH SOPs %',
+            'Total Visits',
+            'Call Rate',
+        ];
+    }
+
+    public function styles(Worksheet $sheet)
+    {
+        $lastColumn = 'S';
+
+        $sheet->getColumnDimension('A')->setWidth(6);
+        $sheet->getColumnDimension('B')->setWidth(25);
+        $sheet->getColumnDimension('C')->setWidth(18);
+
+        foreach (range('D', $lastColumn) as $column) {
+            $sheet->getColumnDimension($column)->setWidth(14);
+        }
+
+        // Style the header row
+        $sheet->getStyle("A1:{$lastColumn}1")->applyFromArray([
+            'font' => [
+                'bold' => true,
+                'color' => ['rgb' => 'FFFFFF'],
+                'size' => 12,
+            ],
+            'fill' => [
+                'fillType' => Fill::FILL_SOLID,
+                'startColor' => ['rgb' => '2C3E50'],
+            ],
+            'alignment' => [
+                'horizontal' => Alignment::HORIZONTAL_CENTER,
+                'vertical' => Alignment::VERTICAL_CENTER,
+            ],
+            'borders' => [
+                'allBorders' => [
+                    'borderStyle' => Border::BORDER_THIN,
+                    'color' => ['rgb' => '000000'],
+                ],
+            ],
+        ]);
+
+        $sheet->getRowDimension(1)->setRowHeight(25);
+
+        // Style the data rows
+        $lastRow = $sheet->getHighestRow();
+        if ($lastRow > 1) {
+            $sheet->getStyle("A2:{$lastColumn}{$lastRow}")->applyFromArray([
+                'borders' => [
+                    'allBorders' => [
+                        'borderStyle' => Border::BORDER_THIN,
+                        'color' => ['rgb' => 'DDDDDD'],
+                    ],
+                ],
+                'alignment' => [
+                    'horizontal' => Alignment::HORIZONTAL_CENTER,
+                    'vertical' => Alignment::VERTICAL_CENTER,
+                ],
+            ]);
+        }
+
+        // Freeze the header row
+        $sheet->freezePane('A2');
+    }
+
+    /**
+     * Generate filename for the export
+     */
+    public function getFilename(): string
+    {
+        $dateRange = $this->dateRange ?? now()->format('Y-m-d_H-i-s');
+
+        return 'all_activity_sops_report_' . $dateRange . '.xlsx';
+    }
+}

--- a/app/Filament/Resources/AllActivitySOPsReportResource.php
+++ b/app/Filament/Resources/AllActivitySOPsReportResource.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Exports\AllActivitySOPsReportExport;
+use App\Filament\Resources\AllActivitySOPsReportResource\Pages;
+use App\Models\AllActivitySOPsReport;
+use App\Models\Scopes\GetMineScope;
+use App\Traits\ResourceHasPermission;
+use Filament\Forms;
+use Filament\Resources\Pages\ListRecords;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\DB;
+
+class AllActivitySOPsReportResource extends Resource
+{
+    use ResourceHasPermission;
+
+    protected static ?string $model = AllActivitySOPsReport::class;
+
+    protected static ?string $label = 'All Activity SOPs';
+    protected static ?string $navigationLabel = 'All Activity SOPs Report';
+    protected static ?string $navigationGroup = 'Reports';
+    protected static ?string $navigationIcon = 'heroicon-o-chart-bar-square';
+    protected static ?string $slug = 'all-activity-sops-report';
+    protected static ?string $permissionName = 'all-activity-sops-report';
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns(self::getColumns())
+            ->filters(self::getFilters())
+            ->filtersLayout(Tables\Enums\FiltersLayout::AboveContent)
+            ->paginated(false)
+            ->headerActions(self::getHeaderActions())
+            ->actions([])
+            ->bulkActions([]);
+    }
+
+    protected static function getColumns(): array
+    {
+        return [
+            TextColumn::make('name')
+                ->label('User Name')
+                ->searchable(),
+            TextColumn::make('role_name')
+                ->label('Role'),
+            TextColumn::make('working_days')
+                ->label('Working Days')
+                ->numeric(),
+            TextColumn::make('actual_working_days')
+                ->label('Actual Working Days')
+                ->numeric(),
+            TextColumn::make('am_visits')
+                ->label('AM Visits')
+                ->numeric(),
+            TextColumn::make('am_monthly_target')
+                ->label('AM Target')
+                ->numeric(decimalPlaces: 2),
+            TextColumn::make('am_sops')
+                ->label('AM SOPs %')
+                ->numeric(decimalPlaces: 2),
+            TextColumn::make('pm_visits')
+                ->label('PM Visits')
+                ->numeric(),
+            TextColumn::make('pm_monthly_target')
+                ->label('PM Target')
+                ->numeric(decimalPlaces: 2),
+            TextColumn::make('pm_sops')
+                ->label('PM SOPs %')
+                ->numeric(decimalPlaces: 2),
+            TextColumn::make('ph_visits')
+                ->label('PH Visits')
+                ->numeric(),
+            TextColumn::make('ph_monthly_target')
+                ->label('PH Target')
+                ->numeric(decimalPlaces: 2),
+            TextColumn::make('ph_sops')
+                ->label('PH SOPs %')
+                ->numeric(decimalPlaces: 2),
+            TextColumn::make('total_visits')
+                ->label('Total Visits')
+                ->numeric(),
+            TextColumn::make('call_rate')
+                ->label('Call Rate')
+                ->numeric(decimalPlaces: 2),
+        ];
+    }
+
+    protected static function getFilters(): array
+    {
+        return [
+            Tables\Filters\Filter::make('date_range')
+                ->label('Date Range')
+                ->form([
+                    Forms\Components\DatePicker::make('from_date')
+                        ->default(today()->startOfMonth())
+                        ->maxDate(today()),
+                    Forms\Components\DatePicker::make('to_date')
+                        ->default(today())
+                        ->maxDate(today()),
+                ]),
+            Tables\Filters\SelectFilter::make('user_id')
+                ->label('Medical Rep')
+                ->options(function () {
+                    return DB::table('users')
+                        ->whereIn('id', GetMineScope::getUserIds())
+                        ->pluck('name', 'id')
+                        ->toArray();
+                })
+                ->searchable()
+                ->preload()
+                ->multiple(),
+        ];
+    }
+
+    protected static function getHeaderActions(): array
+    {
+        return [
+            Tables\Actions\Action::make('export')
+                ->label('Export to Excel')
+                ->icon('heroicon-o-document-arrow-down')
+                ->color('success')
+                ->action(function (ListRecords $livewire) {
+                    $filters = $livewire->getTableFiltersForm()?->getState() ?? [];
+                    $data = AllActivitySOPsReport::getReportDataWithFilters($filters);
+
+                    $export = new AllActivitySOPsReportExport($data);
+
+                    return $export->download($export->getFilename());
+                }),
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListAllActivitySOPsReports::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/AllActivitySOPsReportResource/Pages/ListAllActivitySOPsReports.php
+++ b/app/Filament/Resources/AllActivitySOPsReportResource/Pages/ListAllActivitySOPsReports.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filament\Resources\AllActivitySOPsReportResource\Pages;
+
+use App\Filament\Resources\AllActivitySOPsReportResource;
+use App\Models\AllActivitySOPsReport;
+use Filament\Resources\Pages\ListRecords;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Facades\Log;
+
+class ListAllActivitySOPsReports extends ListRecords
+{
+    protected static string $resource = AllActivitySOPsReportResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            // No actions needed for read-only reports
+        ];
+    }
+
+    /**
+     * Override to handle service-computed results instead of database queries
+     */
+    public function getTableRecords(): EloquentCollection|\Illuminate\Contracts\Pagination\Paginator|\Illuminate\Contracts\Pagination\CursorPaginator
+    {
+        try {
+            $filtersState = $this->getTableFiltersForm()?->getState() ?? [];
+
+            $rows = AllActivitySOPsReport::getReportDataWithFilters($filtersState);
+
+            $models = $rows->map(function (array $row) {
+                $model = new AllActivitySOPsReport();
+                $model->forceFill($row);
+
+                return $model;
+            });
+
+            return new EloquentCollection($models->all());
+        } catch (\Throwable $e) {
+            Log::error('Error in AllActivitySOPsReport getTableRecords: ' . $e->getMessage());
+
+            return new EloquentCollection([]);
+        }
+    }
+}

--- a/app/Filament/Resources/RoleVisitTargetResource.php
+++ b/app/Filament/Resources/RoleVisitTargetResource.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\RoleVisitTargetResource\Pages;
+use App\Models\ClientType;
+use App\Models\Role;
+use App\Models\RoleVisitTarget;
+use App\Traits\ResourceHasPermission;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Validation\Rules\Unique;
+
+class RoleVisitTargetResource extends Resource
+{
+    use ResourceHasPermission;
+
+    protected static ?string $model = RoleVisitTarget::class;
+
+    protected static ?string $label = 'Role Visit Target';
+    protected static ?string $navigationLabel = 'Role Visit Targets';
+    protected static ?string $navigationIcon = 'heroicon-o-adjustments-horizontal';
+    protected static ?string $navigationGroup = 'Admin management';
+    protected static ?int $navigationSort = 7;
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\Select::make('role_id')
+                    ->label('Role')
+                    ->options(fn () => Role::query()->orderBy('name')->pluck('name', 'id')->toArray())
+                    ->searchable()
+                    ->preload()
+                    ->required(),
+                Forms\Components\Select::make('client_type_id')
+                    ->label('Client Type')
+                    ->options(fn () => ClientType::query()->pluck('name', 'id')->toArray())
+                    ->required()
+                    ->unique(
+                        ignoreRecord: true,
+                        modifyRuleUsing: fn (Unique $rule, Forms\Get $get) => $rule->where('role_id', $get('role_id')),
+                    )
+                    ->validationMessages([
+                        'unique' => 'A target for this role and client type already exists.',
+                    ]),
+                Forms\Components\TextInput::make('daily_target')
+                    ->label('Daily Visit Target')
+                    ->numeric()
+                    ->minValue(0)
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('role.name')
+                    ->label('Role')
+                    ->sortable()
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('clientType.name')
+                    ->label('Client Type')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('daily_target')
+                    ->label('Daily Visit Target')
+                    ->numeric(decimalPlaces: 2)
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('role_id')
+                    ->label('Role')
+                    ->options(fn () => Role::query()->orderBy('name')->pluck('name', 'id')->toArray()),
+                Tables\Filters\SelectFilter::make('client_type_id')
+                    ->label('Client Type')
+                    ->options(fn () => ClientType::query()->pluck('name', 'id')->toArray()),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+                Tables\Actions\DeleteAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListRoleVisitTargets::route('/'),
+            'create' => Pages\CreateRoleVisitTarget::route('/create'),
+            'edit' => Pages\EditRoleVisitTarget::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/RoleVisitTargetResource/Pages/CreateRoleVisitTarget.php
+++ b/app/Filament/Resources/RoleVisitTargetResource/Pages/CreateRoleVisitTarget.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\RoleVisitTargetResource\Pages;
+
+use App\Filament\Resources\RoleVisitTargetResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateRoleVisitTarget extends CreateRecord
+{
+    protected static string $resource = RoleVisitTargetResource::class;
+}

--- a/app/Filament/Resources/RoleVisitTargetResource/Pages/EditRoleVisitTarget.php
+++ b/app/Filament/Resources/RoleVisitTargetResource/Pages/EditRoleVisitTarget.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\RoleVisitTargetResource\Pages;
+
+use App\Filament\Resources\RoleVisitTargetResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditRoleVisitTarget extends EditRecord
+{
+    protected static string $resource = RoleVisitTargetResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/RoleVisitTargetResource/Pages/ListRoleVisitTargets.php
+++ b/app/Filament/Resources/RoleVisitTargetResource/Pages/ListRoleVisitTargets.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\RoleVisitTargetResource\Pages;
+
+use App\Filament\Resources\RoleVisitTargetResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListRoleVisitTargets extends ListRecords
+{
+    protected static string $resource = RoleVisitTargetResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Models/AllActivitySOPsReport.php
+++ b/app/Models/AllActivitySOPsReport.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Models;
+
+use App\Services\AllActivitySOPsReportService;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+class AllActivitySOPsReport extends Model
+{
+    // This model is backed by a service (query builder), not a table
+    public $timestamps = false;
+    public $incrementing = false;
+
+    protected $table = 'all_activity_sops_reports'; // Add table name for compatibility
+    protected $primaryKey = 'id';
+
+    protected $fillable = [
+        'id',
+        'name',
+        'role_name',
+        'working_days',
+        'actual_working_days',
+        'am_visits',
+        'am_daily_target',
+        'am_monthly_target',
+        'am_sops',
+        'pm_visits',
+        'pm_daily_target',
+        'pm_monthly_target',
+        'pm_sops',
+        'ph_visits',
+        'ph_daily_target',
+        'ph_monthly_target',
+        'ph_sops',
+        'total_visits',
+        'call_rate',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'working_days' => 'integer',
+        'actual_working_days' => 'integer',
+        'am_visits' => 'integer',
+        'am_daily_target' => 'float',
+        'am_monthly_target' => 'float',
+        'am_sops' => 'float',
+        'pm_visits' => 'integer',
+        'pm_daily_target' => 'float',
+        'pm_monthly_target' => 'float',
+        'pm_sops' => 'float',
+        'ph_visits' => 'integer',
+        'ph_daily_target' => 'float',
+        'ph_monthly_target' => 'float',
+        'ph_sops' => 'float',
+        'total_visits' => 'integer',
+        'call_rate' => 'float',
+    ];
+
+    /**
+     * Get report rows with filters applied from any source
+     * (Filament table filter state, request parameters, plain arrays).
+     */
+    public static function getReportDataWithFilters(array $filters): Collection
+    {
+        return app(AllActivitySOPsReportService::class)
+            ->getReportData(static::normalizeFilters($filters));
+    }
+
+    /**
+     * Normalize filters from any source into from_date / to_date / user_id.
+     */
+    public static function normalizeFilters(array $filters): array
+    {
+        $dateRange = $filters['date_range'] ?? [];
+
+        $fromDate = $dateRange['from_date'] ?? $filters['from_date'] ?? null;
+        $toDate = $dateRange['to_date'] ?? $filters['to_date'] ?? null;
+
+        $userFilter = $filters['user_id'] ?? null;
+
+        if (is_array($userFilter) && array_key_exists('values', $userFilter)) {
+            $userFilter = $userFilter['values'];
+        }
+
+        $userFilter = array_filter((array) ($userFilter ?? []));
+
+        return [
+            'from_date' => $fromDate
+                ? Carbon::parse($fromDate)->toDateString()
+                : today()->startOfMonth()->toDateString(),
+            'to_date' => $toDate
+                ? Carbon::parse($toDate)->toDateString()
+                : today()->toDateString(),
+            'user_id' => array_map('intval', array_values($userFilter)),
+        ];
+    }
+}

--- a/app/Models/RoleVisitTarget.php
+++ b/app/Models/RoleVisitTarget.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RoleVisitTarget extends Model
+{
+    /**
+     * Settings key used as a global fallback for each client type.
+     */
+    public const SETTING_KEYS = [
+        ClientType::AM => 'daily_am_target',
+        ClientType::PM => 'daily_pm_target',
+        ClientType::PH => 'daily_ph_target',
+    ];
+
+    /**
+     * Hard-coded defaults when neither a role target nor a setting exists.
+     * These mirror the defaults used by App\Models\Setting.
+     */
+    public const SETTING_DEFAULTS = [
+        ClientType::AM => 2,
+        ClientType::PM => 6,
+        ClientType::PH => 8,
+    ];
+
+    protected $fillable = [
+        'role_id',
+        'client_type_id',
+        'daily_target',
+    ];
+
+    protected $casts = [
+        'role_id' => 'integer',
+        'client_type_id' => 'integer',
+        'daily_target' => 'float',
+    ];
+
+    /**
+     * Per-request memo of the whole matrix: [role_id][client_type_id] => daily_target.
+     */
+    protected static ?array $matrixCache = null;
+
+    public function role()
+    {
+        return $this->belongsTo(Role::class);
+    }
+
+    public function clientType()
+    {
+        return $this->belongsTo(ClientType::class);
+    }
+
+    /**
+     * Resolve the daily visit target for a role and client type.
+     *
+     * Resolution rule: use the role-specific target when a matrix row exists,
+     * otherwise fall back to the global settings value (daily_am_target /
+     * daily_pm_target / daily_ph_target).
+     */
+    public static function resolveDailyTarget(?int $roleId, int $clientTypeId): float
+    {
+        if ($roleId !== null) {
+            $matrix = static::getMatrix();
+
+            if (isset($matrix[$roleId][$clientTypeId])) {
+                return $matrix[$roleId][$clientTypeId];
+            }
+        }
+
+        return static::getGlobalDailyTarget($clientTypeId);
+    }
+
+    /**
+     * Get the global (settings-based) daily target for a client type.
+     */
+    public static function getGlobalDailyTarget(int $clientTypeId): float
+    {
+        $key = self::SETTING_KEYS[$clientTypeId] ?? null;
+
+        if ($key === null) {
+            return 0.0;
+        }
+
+        return (float) (Setting::getSetting($key)->value ?? self::SETTING_DEFAULTS[$clientTypeId]);
+    }
+
+    /**
+     * Load the full matrix once per request; the table is tiny.
+     */
+    protected static function getMatrix(): array
+    {
+        if (static::$matrixCache === null) {
+            static::$matrixCache = [];
+
+            foreach (static::query()->get() as $target) {
+                static::$matrixCache[$target->role_id][$target->client_type_id] = (float) $target->daily_target;
+            }
+        }
+
+        return static::$matrixCache;
+    }
+
+    public static function flushMatrixCache(): void
+    {
+        static::$matrixCache = null;
+    }
+
+    protected static function booted(): void
+    {
+        static::saved(fn () => static::flushMatrixCache());
+        static::deleted(fn () => static::flushMatrixCache());
+    }
+}

--- a/app/Services/AllActivitySOPsReportService.php
+++ b/app/Services/AllActivitySOPsReportService.php
@@ -1,0 +1,258 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ClientType;
+use App\Models\RoleVisitTarget;
+use App\Models\Scopes\GetMineScope;
+use App\Models\User;
+use Carbon\CarbonPeriod;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Builds the "All Activity SOPs" report: one row per rep, with every required
+ * activity type (AM accounts / PM doctors / PH pharmacies) counted side by side
+ * and targets resolved per role (role_visit_targets matrix, falling back to the
+ * global settings values).
+ *
+ * Counting rules intentionally mirror the GetSOPsAndCallRateData stored
+ * procedure: only visits with status "visited", non-deleted, within the date
+ * range; double visits are credited to BOTH the rep (user_id) and the
+ * accompanying manager (second_user_id). Working days exclude weekends and
+ * official holidays; actual working days additionally exclude approved office
+ * work days, activity days and approved vacation days.
+ */
+class AllActivitySOPsReportService
+{
+    /**
+     * Report sections keyed by row prefix => client type id.
+     */
+    public const SECTIONS = [
+        'am' => ClientType::AM,
+        'pm' => ClientType::PM,
+        'ph' => ClientType::PH,
+    ];
+
+    public function getReportData(array $filters = []): Collection
+    {
+        $fromDate = Carbon::parse($filters['from_date'] ?? today()->startOfMonth())->toDateString();
+        $toDate = Carbon::parse($filters['to_date'] ?? today())->toDateString();
+
+        $userIds = $this->getFilteredUserIds($filters);
+
+        if (empty($userIds)) {
+            return collect();
+        }
+
+        $users = User::withoutGlobalScopes()
+            ->with('roles')
+            ->whereIn('id', $userIds)
+            ->whereNull('deleted_at')
+            ->orderBy('name')
+            ->get();
+
+        $workingDates = $this->getWorkingDates($fromDate, $toDate);
+        $busyDates = $this->getBusyDatesByUser($fromDate, $toDate, $userIds);
+        $visitCounts = $this->getVisitCountsByUserAndType($fromDate, $toDate, $userIds);
+
+        $workingDays = count($workingDates);
+
+        return $users
+            ->map(function (User $user) use ($workingDates, $workingDays, $busyDates, $visitCounts) {
+                $userBusyDates = $busyDates[$user->id] ?? [];
+                $actualWorkingDays = count(array_filter(
+                    $workingDates,
+                    fn (string $date) => ! isset($userBusyDates[$date])
+                ));
+
+                $role = $user->roles->first();
+
+                $row = [
+                    'id' => $user->id,
+                    'name' => $user->name,
+                    'role_name' => $role->name ?? null,
+                    'working_days' => $workingDays,
+                    'actual_working_days' => $actualWorkingDays,
+                ];
+
+                $totalVisits = 0;
+
+                foreach (self::SECTIONS as $prefix => $clientTypeId) {
+                    $visits = (int) ($visitCounts[$user->id][$clientTypeId] ?? 0);
+                    $dailyTarget = RoleVisitTarget::resolveDailyTarget($role->id ?? null, $clientTypeId);
+                    $monthlyTarget = round($actualWorkingDays * $dailyTarget, 2);
+
+                    $row["{$prefix}_visits"] = $visits;
+                    $row["{$prefix}_daily_target"] = $dailyTarget;
+                    $row["{$prefix}_monthly_target"] = $monthlyTarget;
+                    $row["{$prefix}_sops"] = $monthlyTarget > 0
+                        ? round(($visits / $monthlyTarget) * 100, 2)
+                        : 0.0;
+
+                    $totalVisits += $visits;
+                }
+
+                $row['total_visits'] = $totalVisits;
+                $row['call_rate'] = $actualWorkingDays > 0
+                    ? round($totalVisits / $actualWorkingDays, 2)
+                    : 0.0;
+
+                return $row;
+            })
+            ->values();
+    }
+
+    /**
+     * Get filtered user IDs based on permissions and filters
+     * (same scoping as the existing SOPs and Call Rate report).
+     */
+    protected function getFilteredUserIds(array $filters): array
+    {
+        $userIds = GetMineScope::getUserIds();
+
+        if (empty($userIds)) {
+            $userIds = DB::table('users')->pluck('id')->toArray();
+        }
+
+        if (! empty($filters['user_id'])) {
+            $userIds = array_intersect($userIds, (array) $filters['user_id']);
+        }
+
+        return array_map('intval', array_values($userIds));
+    }
+
+    /**
+     * Calendar working dates in range: excludes weekends and official holidays
+     * (mirrors the stored procedure's working days calculation).
+     *
+     * @return array<int, string> list of Y-m-d dates
+     */
+    protected function getWorkingDates(string $fromDate, string $toDate): array
+    {
+        $holidays = DB::table('official_holidays')
+            ->pluck('date')
+            ->map(fn ($date) => Carbon::parse($date)->toDateString())
+            ->filter(fn (string $date) => $date >= $fromDate && $date <= $toDate)
+            ->flip()
+            ->all();
+
+        $dates = [];
+
+        foreach (CarbonPeriod::create($fromDate, $toDate) as $date) {
+            if (in_array($date->dayOfWeek, [Carbon::SATURDAY, Carbon::SUNDAY], true)) {
+                continue;
+            }
+
+            $dateString = $date->toDateString();
+
+            if (isset($holidays[$dateString])) {
+                continue;
+            }
+
+            $dates[] = $dateString;
+        }
+
+        return $dates;
+    }
+
+    /**
+     * Dates on which each user was busy (approved office work, activities,
+     * approved vacations) and therefore not expected in the field.
+     *
+     * @return array<int, array<string, true>> user id => set of Y-m-d dates
+     */
+    protected function getBusyDatesByUser(string $fromDate, string $toDate, array $userIds): array
+    {
+        $busy = [];
+
+        $officeWorks = DB::table('office_works')
+            ->whereIn('user_id', $userIds)
+            ->where('status', 'approved')
+            ->whereDate('created_at', '>=', $fromDate)
+            ->whereDate('created_at', '<=', $toDate)
+            ->get(['user_id', 'created_at']);
+
+        foreach ($officeWorks as $officeWork) {
+            $busy[(int) $officeWork->user_id][Carbon::parse($officeWork->created_at)->toDateString()] = true;
+        }
+
+        $activities = DB::table('activities')
+            ->whereIn('user_id', $userIds)
+            ->whereDate('date', '>=', $fromDate)
+            ->whereDate('date', '<=', $toDate)
+            ->get(['user_id', 'date']);
+
+        foreach ($activities as $activity) {
+            $busy[(int) $activity->user_id][Carbon::parse($activity->date)->toDateString()] = true;
+        }
+
+        $vacations = DB::table('vacation_durations as vd')
+            ->join('vacation_requests as vr', 'vd.vacation_request_id', '=', 'vr.id')
+            ->where('vr.approved', 1)
+            ->whereIn('vr.user_id', $userIds)
+            ->whereDate('vd.start', '<=', $toDate)
+            ->whereDate('vd.end', '>=', $fromDate)
+            ->get(['vr.user_id', 'vd.start', 'vd.end']);
+
+        foreach ($vacations as $vacation) {
+            $start = max(Carbon::parse($vacation->start)->toDateString(), $fromDate);
+            $end = min(Carbon::parse($vacation->end)->toDateString(), $toDate);
+
+            foreach (CarbonPeriod::create($start, $end) as $day) {
+                $busy[(int) $vacation->user_id][$day->toDateString()] = true;
+            }
+        }
+
+        return $busy;
+    }
+
+    /**
+     * Count visited, non-deleted visits per credited user and client type.
+     * A visit is always credited to its owner (user_id); double visits are
+     * additionally credited to the accompanying manager (second_user_id),
+     * exactly like the GetSOPsAndCallRateData stored procedure.
+     *
+     * @return array<int, array<int, int>> user id => [client type id => count]
+     */
+    protected function getVisitCountsByUserAndType(string $fromDate, string $toDate, array $userIds): array
+    {
+        $baseQuery = fn () => DB::table('visits as v')
+            ->leftJoin('clients as c', 'v.client_id', '=', 'c.id')
+            ->where('v.status', 'visited')
+            ->whereNull('v.deleted_at')
+            ->whereDate('v.visit_date', '>=', $fromDate)
+            ->whereDate('v.visit_date', '<=', $toDate);
+
+        $repRows = $baseQuery()
+            ->whereIn('v.user_id', $userIds)
+            ->select('v.user_id as credited_user_id', 'c.client_type_id')
+            ->selectRaw('COUNT(*) as visits_count')
+            ->groupBy('v.user_id', 'c.client_type_id')
+            ->get();
+
+        $managerRows = $baseQuery()
+            ->whereNotNull('v.second_user_id')
+            ->whereIn('v.second_user_id', $userIds)
+            ->select('v.second_user_id as credited_user_id', 'c.client_type_id')
+            ->selectRaw('COUNT(*) as visits_count')
+            ->groupBy('v.second_user_id', 'c.client_type_id')
+            ->get();
+
+        $counts = [];
+
+        foreach ($repRows->concat($managerRows) as $row) {
+            if ($row->client_type_id === null) {
+                continue;
+            }
+
+            $userId = (int) $row->credited_user_id;
+            $clientTypeId = (int) $row->client_type_id;
+
+            $counts[$userId][$clientTypeId] = ($counts[$userId][$clientTypeId] ?? 0) + (int) $row->visits_count;
+        }
+
+        return $counts;
+    }
+}

--- a/database/migrations/2026_07_07_000001_create_role_visit_targets_table.php
+++ b/database/migrations/2026_07_07_000001_create_role_visit_targets_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('role_visit_targets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('role_id')->constrained('roles')->cascadeOnDelete();
+            $table->foreignId('client_type_id')->constrained('client_types')->cascadeOnDelete();
+            $table->decimal('daily_target', 8, 2)->default(0);
+            $table->timestamps();
+
+            $table->unique(['role_id', 'client_type_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('role_visit_targets');
+    }
+};

--- a/database/migrations/2026_07_07_000002_run_role_visit_targets_seeder.php
+++ b/database/migrations/2026_07_07_000002_run_role_visit_targets_seeder.php
@@ -1,0 +1,24 @@
+<?php
+
+use Database\Seeders\RoleVisitTargetsSeeder;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Artisan;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Artisan::call('db:seed', ['--class' => RoleVisitTargetsSeeder::class]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,5 +15,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(RolesAndPermissionsSeeder::class);
+        $this->call(RoleVisitTargetsSeeder::class);
     }
 }

--- a/database/seeders/RoleVisitTargetsSeeder.php
+++ b/database/seeders/RoleVisitTargetsSeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Role;
+use App\Models\RoleVisitTarget;
+use Illuminate\Database\Seeder;
+
+class RoleVisitTargetsSeeder extends Seeder
+{
+    /**
+     * Seed the medical-rep role with the current global settings values
+     * (daily_am_target / daily_pm_target / daily_ph_target) so report numbers
+     * do not change when the per-role matrix is introduced.
+     */
+    public function run(): void
+    {
+        $role = Role::firstOrCreate(
+            ['name' => 'medical-rep'],
+            ['display_name' => 'Medical Rep']
+        );
+
+        foreach (RoleVisitTarget::SETTING_KEYS as $clientTypeId => $settingKey) {
+            RoleVisitTarget::updateOrCreate(
+                [
+                    'role_id' => $role->id,
+                    'client_type_id' => $clientTypeId,
+                ],
+                [
+                    'daily_target' => RoleVisitTarget::getGlobalDailyTarget($clientTypeId),
+                ]
+            );
+        }
+
+        RoleVisitTarget::flushMatrixCache();
+    }
+}

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -50,6 +50,7 @@ class RolesAndPermissionsSeeder extends Seeder
         'product-visit',
         'region',
         'role',
+        'role-visit-target',
         'setting',
         'speciality',
         'template-file',
@@ -66,6 +67,7 @@ class RolesAndPermissionsSeeder extends Seeder
      */
     private array $reportModels = [
         'sops-and-call-rate',
+        'all-activity-sops-report',
         'expenses-report',
         'visit-coverage-report',
         'accounts-coverage-report',

--- a/tests/Unit/AllActivitySOPsReportServiceTest.php
+++ b/tests/Unit/AllActivitySOPsReportServiceTest.php
@@ -1,0 +1,388 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\ClientType;
+use App\Models\RoleVisitTarget;
+use App\Models\Setting;
+use App\Services\AllActivitySOPsReportService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class AllActivitySOPsReportServiceTest extends TestCase
+{
+    private const CONNECTION = 'all_activity_sops_test';
+
+    // 2026-06-01 is a Monday; 2026-06-01..2026-06-05 is a full Mon-Fri week.
+    private const FROM_DATE = '2026-06-01';
+    private const TO_DATE = '2026-06-05';
+
+    private const MEDICAL_REP_ROLE_ID = 10;
+    private const MANAGER_ROLE_ID = 11;
+
+    private const REP_ID = 1;
+    private const MANAGER_ID = 2;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'database.connections.' . self::CONNECTION => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => true,
+            ],
+        ]);
+        config(['database.default' => self::CONNECTION]);
+        DB::purge(self::CONNECTION);
+
+        Cache::flush();
+        RoleVisitTarget::flushMatrixCache();
+
+        $this->createSchema();
+        $this->seedFixtures();
+    }
+
+    protected function tearDown(): void
+    {
+        RoleVisitTarget::flushMatrixCache();
+        DB::purge(self::CONNECTION);
+
+        parent::tearDown();
+    }
+
+    public function test_report_splits_visit_counts_per_client_type_and_credits_double_visits_to_both_users(): void
+    {
+        $rows = $this->getReportRows();
+
+        $this->assertCount(2, $rows);
+
+        $rep = $rows[self::REP_ID];
+        $manager = $rows[self::MANAGER_ID];
+
+        // Rep: 1 AM + 3 PM + 2 PH visited visits; pending, soft-deleted and
+        // out-of-range visits are excluded.
+        $this->assertSame(1, $rep['am_visits']);
+        $this->assertSame(3, $rep['pm_visits']);
+        $this->assertSame(2, $rep['ph_visits']);
+        $this->assertSame(6, $rep['total_visits']);
+
+        // The double visit (rep + accompanying manager) is credited to BOTH:
+        // it is one of the rep's 3 PM visits and the manager's only PM visit.
+        $this->assertSame(1, $manager['pm_visits']);
+        $this->assertSame(0, $manager['am_visits']);
+        $this->assertSame(0, $manager['ph_visits']);
+        $this->assertSame(1, $manager['total_visits']);
+    }
+
+    public function test_working_days_exclude_weekends_holidays_and_busy_days(): void
+    {
+        $rows = $this->getReportRows();
+
+        // Mon-Fri week minus the official holiday on Thursday => 4 working days.
+        $this->assertSame(4, $rows[self::REP_ID]['working_days']);
+        $this->assertSame(4, $rows[self::MANAGER_ID]['working_days']);
+
+        // Rep has an approved vacation on Tuesday => 3 actual working days.
+        $this->assertSame(3, $rows[self::REP_ID]['actual_working_days']);
+
+        // Manager has approved office work on Wednesday and an activity on
+        // Friday => 2 actual working days.
+        $this->assertSame(2, $rows[self::MANAGER_ID]['actual_working_days']);
+    }
+
+    public function test_targets_resolve_role_matrix_first_then_settings_and_percentages_are_correct(): void
+    {
+        $rows = $this->getReportRows();
+
+        $rep = $rows[self::REP_ID];
+        $manager = $rows[self::MANAGER_ID];
+
+        // Rep role has matrix rows (AM 2 / PM 8 / PH 5), distinct from settings.
+        $this->assertSame(2.0, $rep['am_daily_target']);
+        $this->assertSame(8.0, $rep['pm_daily_target']);
+        $this->assertSame(5.0, $rep['ph_daily_target']);
+
+        // Monthly target = actual working days (3) x daily target.
+        $this->assertSame(6.0, $rep['am_monthly_target']);
+        $this->assertSame(24.0, $rep['pm_monthly_target']);
+        $this->assertSame(15.0, $rep['ph_monthly_target']);
+
+        // SOPs % = visits / monthly target * 100.
+        $this->assertSame(round(1 / 6 * 100, 2), $rep['am_sops']);
+        $this->assertSame(round(3 / 24 * 100, 2), $rep['pm_sops']);
+        $this->assertSame(round(2 / 15 * 100, 2), $rep['ph_sops']);
+
+        // Call rate = total visits / actual working days.
+        $this->assertSame(2.0, $rep['call_rate']);
+
+        // Manager role has NO matrix rows => falls back to global settings
+        // (AM 4 / PM 6 / PH 9), with 2 actual working days.
+        $this->assertSame(4.0, $manager['am_daily_target']);
+        $this->assertSame(6.0, $manager['pm_daily_target']);
+        $this->assertSame(9.0, $manager['ph_daily_target']);
+        $this->assertSame(8.0, $manager['am_monthly_target']);
+        $this->assertSame(12.0, $manager['pm_monthly_target']);
+        $this->assertSame(18.0, $manager['ph_monthly_target']);
+        $this->assertSame(round(1 / 12 * 100, 2), $manager['pm_sops']);
+        $this->assertSame(0.0, $manager['am_sops']);
+        $this->assertSame(0.5, $manager['call_rate']);
+    }
+
+    public function test_resolve_daily_target_uses_role_row_first_then_settings_fallback(): void
+    {
+        // Role with a matrix row.
+        $this->assertSame(5.0, RoleVisitTarget::resolveDailyTarget(self::MEDICAL_REP_ROLE_ID, ClientType::PH));
+
+        // Role without a matrix row falls back to settings.
+        $this->assertSame(9.0, RoleVisitTarget::resolveDailyTarget(self::MANAGER_ROLE_ID, ClientType::PH));
+
+        // No role at all falls back to settings.
+        $this->assertSame(6.0, RoleVisitTarget::resolveDailyTarget(null, ClientType::PM));
+    }
+
+    public function test_user_filter_limits_report_rows(): void
+    {
+        $rows = (new AllActivitySOPsReportService())->getReportData([
+            'from_date' => self::FROM_DATE,
+            'to_date' => self::TO_DATE,
+            'user_id' => [self::MANAGER_ID],
+        ]);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(self::MANAGER_ID, $rows->first()['id']);
+    }
+
+    /**
+     * @return array<int, array> report rows keyed by user id
+     */
+    private function getReportRows(): array
+    {
+        $rows = (new AllActivitySOPsReportService())->getReportData([
+            'from_date' => self::FROM_DATE,
+            'to_date' => self::TO_DATE,
+        ]);
+
+        return $rows->keyBy('id')->all();
+    }
+
+    private function createSchema(): void
+    {
+        Schema::create('users', function ($table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->unsignedBigInteger('parent_id')->nullable();
+            $table->unsignedInteger('_lft')->default(0);
+            $table->unsignedInteger('_rgt')->default(0);
+            $table->timestamp('deleted_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('roles', function ($table) {
+            $table->id();
+            $table->string('name');
+            $table->string('guard_name')->default('web');
+            $table->string('display_name')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('model_has_roles', function ($table) {
+            $table->unsignedBigInteger('role_id');
+            $table->string('model_type');
+            $table->unsignedBigInteger('model_id');
+        });
+
+        Schema::create('client_types', function ($table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        Schema::create('settings', function ($table) {
+            $table->id();
+            $table->integer('order')->nullable();
+            $table->string('name')->nullable();
+            $table->string('key');
+            $table->string('value')->nullable();
+            $table->string('type')->nullable();
+            $table->text('description')->nullable();
+            $table->boolean('hidden')->default(false);
+            $table->timestamps();
+        });
+
+        Schema::create('official_holidays', function ($table) {
+            $table->id();
+            $table->date('date');
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('office_works', function ($table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('status')->default('pending');
+            $table->timestamps();
+        });
+
+        Schema::create('activities', function ($table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->date('date');
+            $table->timestamp('deleted_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('vacation_requests', function ($table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->integer('approved')->default(0);
+            $table->timestamps();
+        });
+
+        Schema::create('vacation_durations', function ($table) {
+            $table->id();
+            $table->unsignedBigInteger('vacation_request_id');
+            $table->date('start');
+            $table->date('end');
+            $table->string('start_shift')->nullable();
+            $table->string('end_shift')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('clients', function ($table) {
+            $table->id();
+            $table->string('name')->nullable();
+            $table->unsignedBigInteger('client_type_id')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('visits', function ($table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedBigInteger('second_user_id')->nullable();
+            $table->unsignedBigInteger('client_id')->nullable();
+            $table->string('status')->default('pending');
+            $table->date('visit_date');
+            $table->timestamp('deleted_at')->nullable();
+            $table->timestamps();
+        });
+
+        // Exercise the real migration for the new table.
+        $migration = include base_path('database/migrations/2026_07_07_000001_create_role_visit_targets_table.php');
+        $migration->up();
+    }
+
+    private function seedFixtures(): void
+    {
+        DB::table('users')->insert([
+            ['id' => self::REP_ID, 'name' => 'Alice Rep'],
+            ['id' => self::MANAGER_ID, 'name' => 'Bob Manager'],
+        ]);
+
+        DB::table('roles')->insert([
+            ['id' => self::MEDICAL_REP_ROLE_ID, 'name' => 'medical-rep', 'guard_name' => 'web'],
+            ['id' => self::MANAGER_ROLE_ID, 'name' => 'district-manager', 'guard_name' => 'web'],
+        ]);
+
+        DB::table('model_has_roles')->insert([
+            ['role_id' => self::MEDICAL_REP_ROLE_ID, 'model_type' => 'App\\Models\\User', 'model_id' => self::REP_ID],
+            ['role_id' => self::MANAGER_ROLE_ID, 'model_type' => 'App\\Models\\User', 'model_id' => self::MANAGER_ID],
+        ]);
+
+        DB::table('client_types')->insert([
+            ['id' => ClientType::PM, 'name' => 'PM'],
+            ['id' => ClientType::PH, 'name' => 'PH'],
+            ['id' => ClientType::AM, 'name' => 'AM'],
+        ]);
+
+        // Global settings targets, intentionally distinct from the matrix.
+        foreach ([
+            ['key' => 'daily_am_target', 'value' => '4'],
+            ['key' => 'daily_pm_target', 'value' => '6'],
+            ['key' => 'daily_ph_target', 'value' => '9'],
+        ] as $index => $setting) {
+            Setting::create([
+                'order' => $index + 1,
+                'name' => $setting['key'],
+                'key' => $setting['key'],
+                'value' => $setting['value'],
+                'type' => 'number',
+            ]);
+        }
+
+        // Matrix targets for the medical-rep role only.
+        foreach ([
+            [ClientType::AM, 2],
+            [ClientType::PM, 8],
+            [ClientType::PH, 5],
+        ] as [$clientTypeId, $target]) {
+            RoleVisitTarget::create([
+                'role_id' => self::MEDICAL_REP_ROLE_ID,
+                'client_type_id' => $clientTypeId,
+                'daily_target' => $target,
+            ]);
+        }
+
+        // Official holiday on Thursday 2026-06-04.
+        DB::table('official_holidays')->insert([
+            ['date' => '2026-06-04', 'name' => 'Holiday'],
+        ]);
+
+        // Rep vacation on Tuesday 2026-06-02 (approved).
+        DB::table('vacation_requests')->insert([
+            ['id' => 1, 'user_id' => self::REP_ID, 'approved' => 1],
+        ]);
+        DB::table('vacation_durations')->insert([
+            ['vacation_request_id' => 1, 'start' => '2026-06-02', 'end' => '2026-06-02'],
+        ]);
+
+        // Manager office work on Wednesday 2026-06-03 (approved) and an
+        // activity on Friday 2026-06-05.
+        DB::table('office_works')->insert([
+            ['user_id' => self::MANAGER_ID, 'status' => 'approved', 'created_at' => '2026-06-03 09:00:00'],
+        ]);
+        DB::table('activities')->insert([
+            ['user_id' => self::MANAGER_ID, 'date' => '2026-06-05'],
+        ]);
+
+        // Clients: one per type.
+        DB::table('clients')->insert([
+            ['id' => 1, 'name' => 'Doctor Client', 'client_type_id' => ClientType::PM],
+            ['id' => 2, 'name' => 'Pharmacy Client', 'client_type_id' => ClientType::PH],
+            ['id' => 3, 'name' => 'Account Client', 'client_type_id' => ClientType::AM],
+        ]);
+
+        $visit = fn (array $attributes) => array_merge([
+            'user_id' => self::REP_ID,
+            'second_user_id' => null,
+            'client_id' => null,
+            'status' => 'visited',
+            'visit_date' => '2026-06-01',
+            'deleted_at' => null,
+        ], $attributes);
+
+        DB::table('visits')->insert([
+            // Rep: 2 solo PM visits + 1 PM double visit with the manager.
+            $visit(['client_id' => 1, 'visit_date' => '2026-06-01']),
+            $visit(['client_id' => 1, 'visit_date' => '2026-06-03']),
+            $visit(['second_user_id' => self::MANAGER_ID, 'client_id' => 1, 'visit_date' => '2026-06-05']),
+            // Rep: 2 PH visits.
+            $visit(['client_id' => 2, 'visit_date' => '2026-06-01']),
+            $visit(['client_id' => 2, 'visit_date' => '2026-06-05']),
+            // Rep: 1 AM visit.
+            $visit(['client_id' => 3, 'visit_date' => '2026-06-03']),
+            // Excluded: not visited.
+            $visit(['client_id' => 1, 'status' => 'pending', 'visit_date' => '2026-06-03']),
+            // Excluded: soft deleted.
+            $visit(['client_id' => 1, 'visit_date' => '2026-06-03', 'deleted_at' => '2026-06-03 10:00:00']),
+            // Excluded: outside date range.
+            $visit(['client_id' => 1, 'visit_date' => '2026-06-10']),
+        ]);
+    }
+}


### PR DESCRIPTION
## Business problem

Reps log many visits, but the SOPs report shows only a few, because it counts one client type at a time (defaulting to doctors/PM). Activity to AM accounts and pharmacies is invisible unless you re-run the report per type, and there is no way to compare a rep's activity against per-type targets in one view. On top of that, daily targets are global settings, so they cannot differ by job title (e.g. a medical rep vs. a future sales/distribution rep).

## Design

**Per-role target matrix with settings fallback.** New `role_visit_targets` table (`role_id`, `client_type_id`, `daily_target` decimal) + `RoleVisitTarget` model. Resolution rule: if a matrix row exists for the user's role and client type, use it; otherwise fall back to the existing global settings (`daily_am_target` / `daily_pm_target` / `daily_ph_target`). The `medical-rep` role is seeded with the current settings values (AM 2, PM 6, PH 8), so report numbers do not change on merge. A small **Role Visit Targets** resource under *Admin management* (next to Settings) lets admins edit the matrix; the unique (role, client type) pair is enforced in both the schema and the form.

**All Activity SOPs report** (*Reports* nav group): one row per rep in scope, with working days and actual working days, then AM / PM / PH sections side by side (actual visits, monthly target = actual working days x resolved daily target, SOPs %), plus total visits and overall call rate. Filters: date range defaulting to the current month, and a rep multi-select scoped through `GetMineScope` exactly like the existing SOPs report. Excel export follows the ExpensesReport export pattern.

**Implementation approach:** a dedicated `AllActivitySOPsReportService` built on the query builder (a la `AccountsCoverageReport`) rather than calling the `GetSOPsAndCallRateData` stored procedure once per client type. Reasons:

- The SP's internal target selection has a known bug being fixed in a separate open PR; this feature must not depend on it, and targets here are per-role anyway (the SP only knows global settings).
- One pass computes all three sections (3 SP calls per page load avoided), and the pure-PHP/portable-SQL implementation is coverable by an in-memory SQLite test, which a MySQL-only procedure is not.
- The counting rules deliberately mirror the SP so numbers reconcile with the existing single-type report: only `status='visited'`, non-deleted visits in the date range; double visits credited to BOTH the rep (`user_id`) and the accompanying manager (`second_user_id`); working days = calendar minus weekends and official holidays; actual working days additionally exclude approved office-work days, activity days and approved vacation days.

The existing SOPs and Call Rate report, its service and the stored procedure are untouched.

## What changed

- `database/migrations/2026_07_07_000001_create_role_visit_targets_table.php`, `2026_07_07_000002_run_role_visit_targets_seeder.php`
- `app/Models/RoleVisitTarget.php`, `database/seeders/RoleVisitTargetsSeeder.php`
- `app/Filament/Resources/RoleVisitTargetResource.php` (+ List/Create/Edit pages)
- `app/Services/AllActivitySOPsReportService.php`, `app/Models/AllActivitySOPsReport.php`
- `app/Filament/Resources/AllActivitySOPsReportResource.php` (+ List page), `app/Exports/AllActivitySOPsReportExport.php`
- `database/seeders/RolesAndPermissionsSeeder.php`: `role-visit-target` added to standard models, `all-activity-sops-report` added to report models; `DatabaseSeeder` now calls `RoleVisitTargetsSeeder`
- `tests/Unit/AllActivitySOPsReportServiceTest.php`

## How to verify

1. `php artisan migrate` (creates the table and seeds the medical-rep matrix from current settings)
2. `php artisan db:seed --class=RolesAndPermissionsSeeder` (registers the two new permissions; grant `view all-activity-sops-report` / `role-visit-target` permissions to the relevant roles)
3. Open *Reports -> All Activity SOPs Report*: every rep shows AM/PM/PH visits, targets and SOPs % side by side; compare each section against the existing SOPs report filtered to that client type - visit counts match.
4. Open *Admin management -> Role Visit Targets*, change a target, reload the report - the section target and SOPs % update.
5. `./vendor/bin/pest tests/Unit/AllActivitySOPsReportServiceTest.php` - covers per-type splits, double-visit crediting to both users, role-first-then-settings target resolution, working-day exclusions and percentage math on in-memory SQLite.

## Caveats

- Management's requested values (medical rep 2 AM / 5 PH / 8 PM per day, sales rep 10 PH or warehouses per day) are a data-entry step: the medical-rep row is seeded with today's settings values on purpose so nothing changes on merge, and a sales/distribution-rep role does not exist yet. Once the role is created, its targets are one row per client type in the new admin screen.
- Total visits / call rate sum the three AM/PM/PH sections; visits to clients of any other (currently unused) client type are not counted.
- This PR appends to `$reportModels` in `RolesAndPermissionsSeeder`, as does another open PR - a trivial merge conflict there is expected.
- Warehouses are not a client type today; when they become one, the "10 pharmacies **or warehouses**" target will need either a combined section or a new matrix row semantics (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)