### PR TITLE
feat(client): per-user client lists with Excel export and coverage integration

### DIFF
--- a/app/Exports/ClientListExport.php
+++ b/app/Exports/ClientListExport.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Exports;
+
+use Illuminate\Support\Str;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Style\Border;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+/**
+ * Exports a user's personal client list with the fields the field team
+ * evaluates against: client name, type, class (A/B/C), brick and the
+ * governorate / region resolved through brick -> city -> governorate -> region.
+ */
+class ClientListExport implements FromCollection, WithHeadings, WithStyles
+{
+    use Exportable;
+
+    private $query;
+    private $userName;
+
+    public function __construct($query, ?string $userName = null)
+    {
+        $this->query = $query;
+        $this->userName = $userName;
+    }
+
+    public function collection()
+    {
+        try {
+            $data = $this->query->get();
+
+            if ($data->isEmpty()) {
+                return collect([
+                    ['No clients found in this list']
+                ]);
+            }
+
+            return $data->map(function ($client) {
+                $governorate = $client->brick?->city?->governorate;
+
+                return [
+                    $client->name_en ?? '',
+                    $client->name_ar ?? '',
+                    $client->clientType?->name ?? '',
+                    $client->grade ?? '',
+                    $client->brick?->name ?? '',
+                    $governorate?->name ?? '',
+                    $governorate?->region?->name ?? '',
+                ];
+            });
+        } catch (\Exception $e) {
+            // Return error message if data collection fails
+            return collect([
+                ['Error collecting data: ' . $e->getMessage()]
+            ]);
+        }
+    }
+
+    public function headings(): array
+    {
+        return [
+            'Client Name',
+            'Client Name (العربية)',
+            'Client Type',
+            'Class',
+            'Brick',
+            'Governorate',
+            'Region',
+        ];
+    }
+
+    public function styles(Worksheet $sheet)
+    {
+        // Set column widths
+        $sheet->getColumnDimension('A')->setWidth(30);
+        $sheet->getColumnDimension('B')->setWidth(30);
+        $sheet->getColumnDimension('C')->setWidth(15);
+        $sheet->getColumnDimension('D')->setWidth(10);
+        $sheet->getColumnDimension('E')->setWidth(20);
+        $sheet->getColumnDimension('F')->setWidth(20);
+        $sheet->getColumnDimension('G')->setWidth(20);
+
+        // Style the header row
+        $sheet->getStyle('A1:G1')->applyFromArray([
+            'font' => [
+                'bold' => true,
+                'color' => ['rgb' => 'FFFFFF'],
+                'size' => 12,
+            ],
+            'fill' => [
+                'fillType' => Fill::FILL_SOLID,
+                'startColor' => ['rgb' => '2C3E50'],
+            ],
+            'alignment' => [
+                'horizontal' => Alignment::HORIZONTAL_CENTER,
+                'vertical' => Alignment::VERTICAL_CENTER,
+            ],
+            'borders' => [
+                'allBorders' => [
+                    'borderStyle' => Border::BORDER_THIN,
+                    'color' => ['rgb' => '000000'],
+                ],
+            ],
+        ]);
+
+        // Set row height for header
+        $sheet->getRowDimension(1)->setRowHeight(25);
+
+        // Style the data rows
+        $lastRow = $sheet->getHighestRow();
+        if ($lastRow > 1) {
+            $sheet->getStyle("A2:G{$lastRow}")->applyFromArray([
+                'borders' => [
+                    'allBorders' => [
+                        'borderStyle' => Border::BORDER_THIN,
+                        'color' => ['rgb' => 'DDDDDD'],
+                    ],
+                ],
+                'alignment' => [
+                    'vertical' => Alignment::VERTICAL_CENTER,
+                ],
+            ]);
+
+            // Center the class / brick / geography columns
+            $sheet->getStyle("C2:G{$lastRow}")->getAlignment()
+                ->setHorizontal(Alignment::HORIZONTAL_CENTER);
+        }
+
+        // Freeze the header row
+        $sheet->freezePane('A2');
+    }
+
+    /**
+     * Generate filename for the export
+     */
+    public function getFilename(): string
+    {
+        $owner = Str::slug($this->userName ?? 'user', '_');
+
+        return 'client_list_' . $owner . '_' . now()->format('Y-m-d_H-i-s') . '.xlsx';
+    }
+}

--- a/app/Filament/Resources/MyClientListResource.php
+++ b/app/Filament/Resources/MyClientListResource.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Exports\ClientListExport;
+use App\Filament\Resources\MyClientListResource\Pages;
+use App\Models\Client;
+use App\Models\Scopes\GetMineScope;
+use App\Models\User;
+use App\Models\UserBricksView;
+use App\Traits\ResourceHasPermission;
+use Filament\Forms\Form;
+use Filament\Notifications\Notification;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Personal client lists.
+ *
+ * Every employee covering a region shares the same area-derived client base
+ * (Client::scopeInMyAreas). This resource lets each employee build a
+ * personal, accountable list selected from that pool. Coverage reporting
+ * evaluates against the personal list when one exists and falls back to the
+ * area-derived pool otherwise (Client::scopeAccountablePool).
+ *
+ * Medical reps manage only their own list. Managers (and super admins) can
+ * pick a team member (hierarchy descendants only) to view and manage that
+ * member's list.
+ */
+class MyClientListResource extends Resource
+{
+    use ResourceHasPermission;
+
+    protected static ?string $model = Client::class;
+    protected static ?string $permissionName = 'my-client-list';
+    protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-check';
+    protected static ?string $navigationGroup = 'Admin management';
+    protected static ?string $navigationLabel = 'My Client List';
+    protected static ?string $pluralModelLabel = 'My Client List';
+    protected static ?string $slug = 'my-client-list';
+    protected static ?int $navigationSort = 2;
+
+    protected static ?array $manageableUsers = null;
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name_en')
+                    ->label('Name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('name_ar')
+                    ->label('Name (العربية)')
+                    ->searchable()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                TextColumn::make('clientType.name')
+                    ->label('Type')
+                    ->sortable(),
+                TextColumn::make('grade')
+                    ->label('Class')
+                    ->badge()
+                    ->sortable(),
+                TextColumn::make('brick.name')
+                    ->label('Brick')
+                    ->sortable(),
+                TextColumn::make('brick.city.governorate.name')
+                    ->label('Governorate')
+                    ->toggleable(),
+                TextColumn::make('brick.city.governorate.region.name')
+                    ->label('Region')
+                    ->toggleable(),
+                IconColumn::make('in_list')
+                    ->label('In My List')
+                    ->boolean()
+                    ->getStateUsing(
+                        fn (Client $record, $livewire): bool => self::isInList($record, $livewire),
+                    ),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('user')
+                    ->label("Team Member (View / Manage a Team Member's List)")
+                    ->searchable()
+                    ->placeholder('My own list')
+                    ->options(fn () => self::getManageableUsers())
+                    ->visible(fn () => count(self::getManageableUsers()) > 1)
+                    ->query(function (Builder $query, array $data) {
+                        $userId = $data['value'] ?? null;
+
+                        if (!empty($userId) && self::canManageUser((int) $userId)) {
+                            // Show the selected team member's eligible pool
+                            // (their bricks) instead of the viewer's own.
+                            $query->whereIn(
+                                'brick_id',
+                                UserBricksView::getUserBrickIds((int) $userId),
+                            );
+                        }
+
+                        return $query;
+                    }),
+                Tables\Filters\TernaryFilter::make('list_membership')
+                    ->label('List Membership')
+                    ->placeholder('All eligible clients')
+                    ->trueLabel('In the list')
+                    ->falseLabel('Not in the list')
+                    ->queries(
+                        true: fn (Builder $query, $livewire) => self::applyMembershipConstraint($query, $livewire, true),
+                        false: fn (Builder $query, $livewire) => self::applyMembershipConstraint($query, $livewire, false),
+                        blank: fn (Builder $query) => $query,
+                    ),
+                Tables\Filters\SelectFilter::make('clientType')
+                    ->relationship('clientType', 'name'),
+                Tables\Filters\SelectFilter::make('grade')
+                    ->label('Class')
+                    ->options([
+                        'A' => 'A',
+                        'B' => 'B',
+                        'C' => 'C',
+                        'N' => 'N',
+                        'PH' => 'PH',
+                    ]),
+            ])
+            ->headerActions([
+                Tables\Actions\Action::make('exportList')
+                    ->label('Export List to Excel')
+                    ->icon('heroicon-o-document-arrow-down')
+                    ->color('success')
+                    ->action(function ($livewire) {
+                        try {
+                            $userId = self::getDisplayedUserId($livewire);
+                            $user = User::withoutGlobalScopes()->find($userId);
+
+                            $query = Client::query()
+                                ->whereExists(function ($sub) use ($userId) {
+                                    $sub->select(DB::raw(1))
+                                        ->from('client_user')
+                                        ->whereColumn('client_user.client_id', 'clients.id')
+                                        ->where('client_user.user_id', $userId);
+                                })
+                                ->with(['clientType', 'brick.city.governorate.region'])
+                                ->orderBy('name_en');
+
+                            $export = new ClientListExport($query, $user?->name);
+
+                            return $export->download($export->getFilename());
+                        } catch (\Exception $e) {
+                            return redirect()
+                                ->back()
+                                ->with('error', 'Export failed: ' . $e->getMessage());
+                        }
+                    }),
+            ])
+            ->actions([
+                Tables\Actions\Action::make('addToList')
+                    ->label('Add to List')
+                    ->icon('heroicon-o-plus-circle')
+                    ->color('success')
+                    ->visible(
+                        fn (Client $record, $livewire): bool => !self::isInList($record, $livewire),
+                    )
+                    ->action(function (Client $record, $livewire) {
+                        $userId = self::getDisplayedUserId($livewire);
+                        $record->users()->syncWithoutDetaching([$userId]);
+
+                        Notification::make()
+                            ->title('Client added to the list')
+                            ->success()
+                            ->send();
+                    }),
+                Tables\Actions\Action::make('removeFromList')
+                    ->label('Remove from List')
+                    ->icon('heroicon-o-minus-circle')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->modalHeading('Remove Client from List')
+                    ->modalDescription('Are you sure you want to remove this client from the list?')
+                    ->visible(
+                        fn (Client $record, $livewire): bool => self::isInList($record, $livewire),
+                    )
+                    ->action(function (Client $record, $livewire) {
+                        $userId = self::getDisplayedUserId($livewire);
+                        $record->users()->detach($userId);
+
+                        Notification::make()
+                            ->title('Client removed from the list')
+                            ->success()
+                            ->send();
+                    }),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkAction::make('addSelectedToList')
+                    ->label('Add Selected to List')
+                    ->icon('heroicon-o-plus-circle')
+                    ->color('success')
+                    ->requiresConfirmation()
+                    ->modalHeading('Add Selected Clients to List')
+                    ->modalDescription('This will add all selected clients to the displayed list.')
+                    ->deselectRecordsAfterCompletion()
+                    ->action(function ($records, $livewire) {
+                        $userId = self::getDisplayedUserId($livewire);
+
+                        foreach ($records as $record) {
+                            $record->users()->syncWithoutDetaching([$userId]);
+                        }
+
+                        Notification::make()
+                            ->title('Selected clients added to the list')
+                            ->success()
+                            ->send();
+                    }),
+                Tables\Actions\BulkAction::make('removeSelectedFromList')
+                    ->label('Remove Selected from List')
+                    ->icon('heroicon-o-minus-circle')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->modalHeading('Remove Selected Clients from List')
+                    ->modalDescription('This will remove all selected clients from the displayed list.')
+                    ->deselectRecordsAfterCompletion()
+                    ->action(function ($records, $livewire) {
+                        $userId = self::getDisplayedUserId($livewire);
+
+                        foreach ($records as $record) {
+                            $record->users()->detach($userId);
+                        }
+
+                        Notification::make()
+                            ->title('Selected clients removed from the list')
+                            ->success()
+                            ->send();
+                    }),
+            ])
+            ->defaultPaginationPageOption(25)
+            ->paginationPageOptions([25, 50, 100, 250]);
+    }
+
+    /**
+     * The eligible pool: clients in the viewer's areas. When a manager picks
+     * a team member in the "user" filter, the pool is narrowed to that
+     * member's bricks (see the filter query above).
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->with([
+                'clientType',
+                'brick',
+                'users' => fn ($query) => $query->select('users.id'),
+            ])
+            ->scopes(['inMyAreas']);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListMyClientLists::route('/'),
+        ];
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function canEdit($record): bool
+    {
+        return false;
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    /**
+     * Resolve whose list is being displayed / managed: the team member
+     * selected in the "user" filter (when allowed), or the viewer.
+     */
+    public static function getDisplayedUserId($livewire = null): int
+    {
+        $userId = null;
+
+        if ($livewire && method_exists($livewire, 'getTableFilterState')) {
+            $userId = $livewire->getTableFilterState('user')['value'] ?? null;
+        }
+
+        if (empty($userId)) {
+            $userId = request()->input('tableFilters.user.value');
+        }
+
+        if (!empty($userId) && self::canManageUser((int) $userId)) {
+            return (int) $userId;
+        }
+
+        return (int) auth()->id();
+    }
+
+    public static function isInList(Client $record, $livewire = null): bool
+    {
+        return $record->users->contains('id', self::getDisplayedUserId($livewire));
+    }
+
+    /**
+     * Users whose lists the viewer may see and manage: themselves and their
+     * hierarchy descendants (same visibility rule as GetMineScope).
+     */
+    public static function getManageableUsers(): array
+    {
+        if (self::$manageableUsers !== null) {
+            return self::$manageableUsers;
+        }
+
+        return self::$manageableUsers = User::getMine()
+            ->pluck('name', 'id')
+            ->toArray();
+    }
+
+    public static function canManageUser(int $userId): bool
+    {
+        return in_array($userId, GetMineScope::getUserIds());
+    }
+
+    protected static function applyMembershipConstraint(Builder $query, $livewire, bool $inList): Builder
+    {
+        $userId = self::getDisplayedUserId($livewire);
+        $method = $inList ? 'whereExists' : 'whereNotExists';
+
+        return $query->{$method}(function ($sub) use ($userId) {
+            $sub->select(DB::raw(1))
+                ->from('client_user')
+                ->whereColumn('client_user.client_id', 'clients.id')
+                ->where('client_user.user_id', $userId);
+        });
+    }
+}

--- a/app/Filament/Resources/MyClientListResource/Pages/ListMyClientLists.php
+++ b/app/Filament/Resources/MyClientListResource/Pages/ListMyClientLists.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Resources\MyClientListResource\Pages;
+
+use App\Filament\Resources\MyClientListResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListMyClientLists extends ListRecords
+{
+    protected static string $resource = MyClientListResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+
+    public function isTableSearchable(): bool
+    {
+        return true;
+    }
+}

--- a/app/Models/AccountsCoverageReport.php
+++ b/app/Models/AccountsCoverageReport.php
@@ -57,8 +57,88 @@ class AccountsCoverageReport extends Model
     ];
 
     /**
+     * SQL for the per-user accountable client pool (user_id, client_id rows).
+     *
+     * Users WITH a personal client list (client_user rows) are evaluated
+     * against that list; users WITHOUT one keep the legacy area-derived pool
+     * from user_bricks_view. Both branches respect the active flag and the
+     * client type filter. See Client::scopeAccountablePool for the same rule
+     * on the Eloquent side.
+     */
+    private static function buildAccountableClientsPoolSql(int $clientTypeId, string $userIdsStr): string
+    {
+        return "
+                    SELECT
+                        cu.user_id,
+                        cu.client_id
+                    FROM client_user cu
+                    JOIN clients c ON cu.client_id = c.id
+                    WHERE c.active = 1
+                      AND c.client_type_id = {$clientTypeId}
+                      AND cu.user_id IN ({$userIdsStr})
+                    UNION ALL
+                    SELECT
+                        ubv.user_id,
+                        c.id as client_id
+                    FROM user_bricks_view ubv
+                    JOIN clients c ON ubv.brick_id = c.brick_id
+                    WHERE c.active = 1
+                      AND c.client_type_id = {$clientTypeId}
+                      AND ubv.user_id IN ({$userIdsStr})
+                      AND NOT EXISTS (SELECT 1 FROM client_user cux WHERE cux.user_id = ubv.user_id)
+        ";
+    }
+
+    /**
+     * SQL for visits restricted to each user's accountable client pool
+     * (personal list when present, legacy area-derived pool otherwise).
+     *
+     * @param string $select        Columns to select from the visits alias `v`
+     * @param string $extraCondition Additional WHERE fragment (e.g. plan filter)
+     */
+    private static function buildAccountableVisitsPoolSql(
+        string $select,
+        string $extraCondition,
+        string $fromDate,
+        string $toDate,
+        int $clientTypeId,
+        string $userIdsStr
+    ): string {
+        return "
+                    SELECT {$select}
+                    FROM visits v
+                    JOIN clients c ON v.client_id = c.id
+                    JOIN client_user cu ON cu.client_id = c.id AND cu.user_id = v.user_id
+                    WHERE v.status = 'visited'
+                      AND DATE(v.visit_date) BETWEEN '{$fromDate}' AND '{$toDate}'
+                      AND v.deleted_at IS NULL
+                      AND c.active = 1
+                      AND c.client_type_id = {$clientTypeId}
+                      {$extraCondition}
+                      AND cu.user_id IN ({$userIdsStr})
+                    UNION ALL
+                    SELECT {$select}
+                    FROM visits v
+                    JOIN clients c ON v.client_id = c.id
+                    JOIN user_bricks_view ubv ON c.brick_id = ubv.brick_id AND v.user_id = ubv.user_id
+                    WHERE v.status = 'visited'
+                      AND DATE(v.visit_date) BETWEEN '{$fromDate}' AND '{$toDate}'
+                      AND v.deleted_at IS NULL
+                      AND c.active = 1
+                      AND c.client_type_id = {$clientTypeId}
+                      {$extraCondition}
+                      AND ubv.user_id IN ({$userIdsStr})
+                      AND NOT EXISTS (SELECT 1 FROM client_user cux WHERE cux.user_id = v.user_id)
+        ";
+    }
+
+    /**
      * Build the accounts coverage report query using the user_bricks_view
-     * This view consolidates user brick access through direct assignments and area-based access
+     * This view consolidates user brick access through direct assignments and area-based access.
+     *
+     * Users who maintain a personal client list (client_user rows) have their
+     * denominators and coverage counts computed over that list instead of the
+     * area-derived pool; users without one keep the legacy behavior.
      */
     public static function buildReportQuery(string $fromDate, string $toDate, ?array $medicalRepIds = null, ?int $clientTypeId = null): Builder
     {
@@ -111,91 +191,45 @@ class AccountsCoverageReport extends Model
             ])
             ->leftJoin(DB::raw("(
                 SELECT
-                    ubv.user_id,
-                    COUNT(DISTINCT c.id) as total_clients
-                FROM user_bricks_view ubv
-                JOIN clients c ON ubv.brick_id = c.brick_id
-                WHERE c.active = 1
-                  AND c.client_type_id = {$clientTypeId}
-                  AND ubv.user_id IN ({$userIdsStr})
-                GROUP BY ubv.user_id
+                    pool.user_id,
+                    COUNT(DISTINCT pool.client_id) as total_clients
+                FROM (" . self::buildAccountableClientsPoolSql($clientTypeId, $userIdsStr) . ") as pool
+                GROUP BY pool.user_id
             ) as area_clients"), 'users.id', '=', 'area_clients.user_id')
             ->leftJoin(DB::raw("(
                 SELECT
-                    v.user_id,
-                    COUNT(DISTINCT v.client_id) as visited_count
-                FROM visits v
-                JOIN clients c ON v.client_id = c.id
-                JOIN user_bricks_view ubv ON c.brick_id = ubv.brick_id AND v.user_id = ubv.user_id
-                WHERE v.status = 'visited'
-                  AND DATE(v.visit_date) BETWEEN '{$fromDate}' AND '{$toDate}'
-                  AND v.deleted_at IS NULL
-                  AND c.active = 1
-                  AND c.client_type_id = {$clientTypeId}
-                  AND ubv.user_id IN ({$userIdsStr})
-                GROUP BY v.user_id
+                    pool.user_id,
+                    COUNT(DISTINCT pool.client_id) as visited_count
+                FROM (" . self::buildAccountableVisitsPoolSql('v.user_id, v.client_id', '', $fromDate, $toDate, $clientTypeId, $userIdsStr) . ") as pool
+                GROUP BY pool.user_id
             ) as visited_clients"), 'users.id', '=', 'visited_clients.user_id')
             ->leftJoin(DB::raw("(
                 SELECT
-                    v2.user_id,
+                    pool.user_id,
                     COUNT(*) as visit_count
-                FROM visits v2
-                JOIN clients c2 ON v2.client_id = c2.id
-                JOIN user_bricks_view ubv2 ON c2.brick_id = ubv2.brick_id AND v2.user_id = ubv2.user_id
-                WHERE v2.status = 'visited'
-                  AND DATE(v2.visit_date) BETWEEN '{$fromDate}' AND '{$toDate}'
-                  AND v2.deleted_at IS NULL
-                  AND c2.active = 1
-                  AND c2.client_type_id = {$clientTypeId}
-                  AND ubv2.user_id IN ({$userIdsStr})
-                GROUP BY v2.user_id
+                FROM (" . self::buildAccountableVisitsPoolSql('v.user_id', '', $fromDate, $toDate, $clientTypeId, $userIdsStr) . ") as pool
+                GROUP BY pool.user_id
             ) as actual_visits"), 'users.id', '=', 'actual_visits.user_id')
             ->leftJoin(DB::raw("(
                 SELECT
-                    v3.user_id,
+                    pool.user_id,
                     COUNT(*) as clinic_visit_count
-                FROM visits v3
-                JOIN clients c3 ON v3.client_id = c3.id
-                JOIN user_bricks_view ubv3 ON c3.brick_id = ubv3.brick_id AND v3.user_id = ubv3.user_id
-                WHERE v3.status = 'visited'
-                  AND DATE(v3.visit_date) BETWEEN '{$fromDate}' AND '{$toDate}'
-                  AND v3.deleted_at IS NULL
-                  AND c3.client_type_id = {$clientTypeId}
-                  AND c3.active = 1
-                  AND ubv3.user_id IN ({$userIdsStr})
-                GROUP BY v3.user_id
+                FROM (" . self::buildAccountableVisitsPoolSql('v.user_id', '', $fromDate, $toDate, $clientTypeId, $userIdsStr) . ") as pool
+                GROUP BY pool.user_id
             ) as clinic_visits"), 'users.id', '=', 'clinic_visits.user_id')
             ->leftJoin(DB::raw("(
                 SELECT
-                    v4.user_id,
+                    pool.user_id,
                     COUNT(*) as planned_visit_count
-                FROM visits v4
-                JOIN clients c4 ON v4.client_id = c4.id
-                JOIN user_bricks_view ubv4 ON c4.brick_id = ubv4.brick_id AND v4.user_id = ubv4.user_id
-                WHERE v4.status = 'visited'
-                  AND DATE(v4.visit_date) BETWEEN '{$fromDate}' AND '{$toDate}'
-                  AND v4.deleted_at IS NULL
-                  AND v4.plan_id IS NOT NULL
-                  AND c4.active = 1
-                  AND c4.client_type_id = {$clientTypeId}
-                  AND ubv4.user_id IN ({$userIdsStr})
-                GROUP BY v4.user_id
+                FROM (" . self::buildAccountableVisitsPoolSql('v.user_id', 'AND v.plan_id IS NOT NULL', $fromDate, $toDate, $clientTypeId, $userIdsStr) . ") as pool
+                GROUP BY pool.user_id
             ) as planned_visits"), 'users.id', '=', 'planned_visits.user_id')
             ->leftJoin(DB::raw("(
                 SELECT
-                    v5.user_id,
+                    pool.user_id,
                     COUNT(*) as random_visit_count
-                FROM visits v5
-                JOIN clients c5 ON v5.client_id = c5.id
-                JOIN user_bricks_view ubv5 ON c5.brick_id = ubv5.brick_id AND v5.user_id = ubv5.user_id
-                WHERE v5.status = 'visited'
-                  AND DATE(v5.visit_date) BETWEEN '{$fromDate}' AND '{$toDate}'
-                  AND v5.deleted_at IS NULL
-                  AND v5.plan_id IS NULL
-                  AND c5.active = 1
-                  AND c5.client_type_id = {$clientTypeId}
-                  AND ubv5.user_id IN ({$userIdsStr})
-                GROUP BY v5.user_id
+                FROM (" . self::buildAccountableVisitsPoolSql('v.user_id', 'AND v.plan_id IS NULL', $fromDate, $toDate, $clientTypeId, $userIdsStr) . ") as pool
+                GROUP BY pool.user_id
             ) as random_visits"), 'users.id', '=', 'random_visits.user_id')
             ->where('users.is_active', 1)
             ->whereIn('users.id', $userIds)

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -6,6 +6,7 @@ use App\Traits\HasEditRequest;
 use Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 use Staudenmeir\EloquentHasManyDeep\HasRelationships;
 
 class Client extends Model
@@ -171,6 +172,79 @@ class Client extends Model
 
         $brickIds = self::getMyBricksIds();
         return $builder->whereIn("brick_id", $brickIds);
+    }
+
+    /**
+     * Users who have added this client to their personal client list.
+     */
+    public function users()
+    {
+        return $this->belongsToMany(User::class)->withTimestamps();
+    }
+
+    /**
+     * Scope: clients on the authenticated user's personal client list.
+     */
+    public function scopeInMyList($builder)
+    {
+        if (!self::isAuthenticated()) {
+            return;
+        }
+
+        return self::applyPersonalListConstraint($builder, auth()->id());
+    }
+
+    /**
+     * Scope: the "accountable pool" of clients for a user.
+     *
+     * This is the fallback rule used by coverage reporting:
+     * - When the user maintains a personal client list (client_user rows),
+     *   the pool is exactly that list.
+     * - When the user has no personal list, the pool falls back to the
+     *   shared area-derived client base (all clients in the user's bricks,
+     *   as resolved by user_bricks_view — same source as scopeInMyAreas).
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $builder
+     * @param  int|null  $userId  Defaults to the authenticated user.
+     */
+    public function scopeAccountablePool($builder, ?int $userId = null)
+    {
+        $userId = $userId ?? auth()->id();
+
+        if (!$userId) {
+            return;
+        }
+
+        if (self::userHasPersonalList($userId)) {
+            return self::applyPersonalListConstraint($builder, $userId);
+        }
+
+        return $builder->whereIn(
+            "brick_id",
+            UserBricksView::getUserBrickIds($userId),
+        );
+    }
+
+    /**
+     * Whether the given user maintains a personal client list.
+     */
+    public static function userHasPersonalList(int $userId): bool
+    {
+        return DB::table("client_user")->where("user_id", $userId)->exists();
+    }
+
+    /**
+     * Constrain the query to clients on the given user's personal list.
+     */
+    private static function applyPersonalListConstraint($builder, int $userId)
+    {
+        return $builder->whereExists(function ($query) use ($userId) {
+            $query
+                ->select(DB::raw(1))
+                ->from("client_user")
+                ->whereColumn("client_user.client_id", "clients.id")
+                ->where("client_user.user_id", $userId);
+        });
     }
 
     private static function isAuthenticated(): bool

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -91,6 +91,14 @@ class User extends Authenticatable implements FilamentUser
         return $this->belongsToMany(Brick::class);
     }
 
+    /**
+     * The user's personal client list, selected from their area-derived pool.
+     */
+    public function clients()
+    {
+        return $this->belongsToMany(Client::class)->withTimestamps();
+    }
+
     public function myManager()
     {
         return $this->belongsTo(User::class, 'parent_id');

--- a/database/migrations/2026_07_07_000001_create_client_user_table.php
+++ b/database/migrations/2026_07_07_000001_create_client_user_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\Client;
+use App\Models\User;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Personal client lists: each row marks a client as part of a user's
+     * personal (accountable) client list, selected from the user's
+     * area-derived client pool.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('client_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Client::class)->constrained()->cascadeOnDelete();
+            $table->foreignIdFor(User::class)->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['client_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('client_user');
+    }
+};

--- a/database/seeders/MedicalRepRole.php
+++ b/database/seeders/MedicalRepRole.php
@@ -27,6 +27,7 @@ class MedicalRepRole extends Seeder
             'visit-coverage-report' => ['view-any', 'view'],
             'accounts-coverage-report' => ['view-any', 'view'],
             'message' => ['view', 'create', 'update', 'delete'],
+            'my-client-list' => ['view', 'view-any', 'create', 'update', 'delete'],
             'official-holiday' => ['view'],
             'order-report' => ['view'],
             'order' => ['view', 'create', 'update', 'delete'],

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -38,6 +38,7 @@ class RolesAndPermissionsSeeder extends Seeder
         'hospital',
         'item',
         'message',
+        'my-client-list',
         'office-work',
         'official-holiday',
         'order',


### PR DESCRIPTION
## Business problem

The same region is covered by employees with different jobs (medical rep, distribution rep, area manager) who need a different customer focus, and some regions split medical promotion across two lines. Today everyone covering a region sees the identical region-derived client list, so there is no way to hold an individual accountable for a job-specific or line-specific subset, and key-account style lists cannot be expressed at all.

## Design

- **Shared base, personal selection.** The region-derived client base (bricks via `user_bricks_view`) stays untouched. Each employee can now build a personal, accountable list selected from that pool, stored in a new `client_user` pivot (unique per client/user, timestamped).
- **Accountable-pool fallback rule.** `Client::scopeAccountablePool()` (and the equivalent SQL inside the coverage report) resolves a user's pool as: personal list when the user has `client_user` rows, otherwise the legacy area-derived pool. Users who never touch the feature are reported on exactly as before.
- **Manager oversight.** Managers and super admins get a hierarchy-scoped team-member selector (same visibility rule as `GetMineScope` / the ClientResource user filter) to view and manage a subordinate's list. Medical reps only manage their own.

## What changed

- `database/migrations/2026_07_07_000001_create_client_user_table.php` — `client_user` pivot: `client_id`, `user_id`, timestamps, `unique(client_id, user_id)`, FKs with cascade.
- `app/Models/Client.php` — `users()` relation, `scopeInMyList()`, `scopeAccountablePool()`, `userHasPersonalList()`.
- `app/Models/User.php` — `clients()` relation.
- `app/Filament/Resources/MyClientListResource.php` (+ List page) — "My Client List" under *Admin management*: table over the displayed user's eligible area pool with name, type, class, brick, governorate and region columns, an "In My List" indicator, in/not-in-list ternary filter, type/class filters, row + bulk add/remove actions, and the team-member selector.
- `app/Exports/ClientListExport.php` — Excel export (maatwebsite, mirrors `ExpensesReportExport`) of the displayed user's list: client name (EN/AR), client type, class (A/B/C), brick, governorate and region (resolved through brick → city → governorate → region).
- `app/Models/AccountsCoverageReport.php` — every per-user client pool (denominator + all visit-count subqueries) is now a `UNION ALL` of the personal-list branch and the legacy `user_bricks_view` branch guarded by `NOT EXISTS (client_user rows)`, all still respecting `active = 1` and the client-type filter. Users without a list keep the previous SQL semantics unchanged (including join multiplicity).
- `database/seeders/RolesAndPermissionsSeeder.php`, `database/seeders/MedicalRepRole.php` — registers `my-client-list` permissions; district/area/country manager roles inherit them through the existing seeder chain.

## How to verify

1. `php artisan migrate` (creates `client_user`).
2. `php artisan db:seed --class=RolesAndPermissionsSeeder && php artisan db:seed --class=MedicalRepRole && php artisan db:seed --class=DistrictManagerRole && php artisan db:seed --class=AreaManagerRole && php artisan db:seed --class=CountryManagerRole` (registers/propagates the `my-client-list` permissions).
3. As a medical rep: open **Admin management → My Client List**, add/remove clients (row + bulk), filter by membership, then **Export List to Excel** and confirm name/type/class/brick/governorate/region columns.
4. As a manager: use the *Team Member* filter to open a subordinate's pool, manage their list, and export it.
5. Accounts Coverage Report: for a rep **without** a list, all figures must be identical to before this change; after adding a list, `total_area_clients`, visited/unvisited and visit counts are computed against the list only (verified with an in-memory SQLite smoke test asserting the fallback path is equivalent to the original SQL, since removed).

## Caveats

- The list-vs-fallback decision is per user, not per client type: once a user has *any* `client_user` rows, every client-type view of the coverage report evaluates them against their list (filtered to that type). A rep with a doctors-only list will show a zero denominator on the pharmacies report until pharmacies are added to the list.
- The export and coverage counts only include **active** clients; inactive clients stay on the list but are ignored, matching existing report behavior.
- The team-member filter narrows the pool to the subordinate's bricks intersected with the viewer's own visibility (same pattern as the ClientResource user filter); in the expected hierarchy a subordinate's bricks are a subset of the manager's, so this is the subordinate's full pool.
- Clients deleted from the system cascade out of personal lists; deactivated clients do not (deliberate, so reactivation restores the list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)